### PR TITLE
Add Register subcommand to install server credentials

### DIFF
--- a/brownfield/register.go
+++ b/brownfield/register.go
@@ -109,20 +109,20 @@ func configureServerKeys(config *utils.Config, rootCACert, cert, key string) err
 		CaCertPath  string
 	}{config.APIEndpoint, config.LogFile, config.LogLevel,
 		config.Certificate.Cert, config.Certificate.Key, config.Certificate.Ca}
-	if configFileData.LogFile == "" {
-		configFileData.LogFile = "/var/log/concerto-client.log"
-	}
 	if configFileData.LogLevel == "" {
 		configFileData.LogLevel = "info"
 	}
+	if configFileData.LogFile == "" {
+		configFileData.LogFile = utils.GetDefaultLogFilePath()
+	}
 	if configFileData.CaCertPath == "" {
-		configFileData.CaCertPath = "/etc/concerto/client_ssl/ca_cert.pem"
+		configFileData.CaCertPath = utils.GetDefaultCaCertFilePath()
 	}
 	if configFileData.CertPath == "" {
-		configFileData.CertPath = "/etc/concerto/client_ssl/cert.pem"
+		configFileData.CertPath = utils.GetDefaultCertFilePath()
 	}
 	if configFileData.KeyPath == "" {
-		configFileData.KeyPath = "/etc/concerto/client_ssl/private/key.pem"
+		configFileData.KeyPath = utils.GetDefaultKeyFilePath()
 	}
 	err := os.MkdirAll(filepath.Dir(configFileData.CaCertPath), 0644)
 	if err != nil {

--- a/cmdpolling/polling.go
+++ b/cmdpolling/polling.go
@@ -1,0 +1,15 @@
+package cmdpolling
+
+import (
+	"github.com/codegangsta/cli"
+)
+
+func SubCommands() []cli.Command {
+	return []cli.Command{
+		{
+			Name:   "register",
+			Usage:  "Register concerto agent within an imported Host",
+			Action: cmdRegister,
+		},
+	}
+}

--- a/cmdpolling/register.go
+++ b/cmdpolling/register.go
@@ -1,0 +1,166 @@
+package cmdpolling
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"text/template"
+
+	"github.com/codegangsta/cli"
+	"github.com/ingrammicro/concerto/utils"
+	"github.com/ingrammicro/concerto/utils/format"
+)
+
+var configFileTemplate = template.Must(template.New("configFile").Parse(`<concerto version="1.0" server="{{.APIEndpoint}}" log_file="{{.LogFile}}" log_level="{{.LogLevel}}">
+<ssl cert="{{.CertPath}}" key="{{.KeyPath}}" server_ca="{{.CaCertPath}}" />
+</concerto>
+`))
+
+func cmdRegister(c *cli.Context) error {
+	f := format.GetFormatter()
+	config, err := utils.GetConcertoConfig()
+	if err != nil {
+		f.PrintFatal("Couldn't read config", err)
+	}
+	if !config.CurrentUserIsAdmin {
+		if runtime.GOOS == "windows" {
+			f.PrintFatal("Must run as administrator user", fmt.Errorf("running as non-administrator user"))
+		} else {
+			f.PrintFatal("Must run as super-user", fmt.Errorf("running as non-administrator user"))
+		}
+	}
+	rootCACert, cert, key, err := obtainServerKeys(config)
+	if err != nil {
+		f.PrintFatal("Couldn't obtain server keys", err)
+	}
+	err = configureServerKeys(config, rootCACert, cert, key)
+	if err != nil {
+		f.PrintFatal("Couldn't configure server keys", err)
+	}
+	fmt.Printf("Concerto agent successfully registered, configuration file placed at %s\n", config.ConfFile)
+	return nil
+}
+
+func obtainServerKeys(config *utils.Config) (rootCAcert string, cert string, key string, err error) {
+	cs, err := utils.NewHTTPConcertoServiceWithCommandPolling(config)
+	if err != nil {
+		return
+	}
+	payload := make(map[string]interface{})
+	body, status, err := cs.Post("/command_polling/api_key", &payload)
+	if err != nil {
+		return
+	}
+	if status == 403 {
+		err = fmt.Errorf("server responded with 403 code: the polling token is not valid, maybe it expired")
+		return
+	}
+	if status >= 300 {
+		err = fmt.Errorf("server responded with %d code: %s", status, string(body))
+		return
+	}
+	responseData := make(map[string]interface{})
+	err = json.Unmarshal(body, &responseData)
+	if err != nil {
+		return
+	}
+	irootCAcert, ok := responseData["root_ca_cert"]
+	if !ok {
+		err = fmt.Errorf("server response did not include root CA cert: %v", responseData)
+		return
+	}
+	rootCAcert, ok = irootCAcert.(string)
+	if !ok {
+		err = fmt.Errorf("server response returned a %T as root CA cert, expected a string", irootCAcert)
+		return
+	}
+	iCert, ok := responseData["cert"]
+	if !ok {
+		err = fmt.Errorf("server response did not include server cert: %v", responseData)
+		return
+	}
+	cert, ok = iCert.(string)
+	if !ok {
+		err = fmt.Errorf("server response returned a %T as server cert, expected a string", iCert)
+		return
+	}
+	iKey, ok := responseData["key"]
+	if !ok {
+		err = fmt.Errorf("server response did not include server private key: %v", responseData)
+		return
+	}
+	key, ok = iKey.(string)
+	if !ok {
+		err = fmt.Errorf("server response returned a %T as server private key, expected a string", iKey)
+	}
+	return
+}
+
+func configureServerKeys(config *utils.Config, rootCACert, cert, key string) error {
+	configFileData := &struct {
+		APIEndpoint string
+		LogFile     string
+		LogLevel    string
+		CertPath    string
+		KeyPath     string
+		CaCertPath  string
+	}{config.APIEndpoint, config.LogFile, config.LogLevel,
+		config.Certificate.Cert, config.Certificate.Key, config.Certificate.Ca}
+
+	if configFileData.LogLevel == "" {
+		configFileData.LogLevel = "info"
+	}
+	if configFileData.LogFile == "" {
+		configFileData.LogFile = utils.GetConfigFilePath("LogFile")
+	}
+	if configFileData.CaCertPath == "" {
+		configFileData.CaCertPath = utils.GetConfigFilePath("CaCertPath")
+	}
+	if configFileData.CertPath == "" {
+		configFileData.CertPath = utils.GetConfigFilePath("CertPath")
+	}
+	if configFileData.KeyPath == "" {
+		configFileData.KeyPath = utils.GetConfigFilePath("KeyPath")
+	}
+	err := os.MkdirAll(filepath.Dir(configFileData.CaCertPath), 0644)
+	if err != nil {
+		return fmt.Errorf("cannot create directory to place root CA cert: %v", err)
+	}
+	err = ioutil.WriteFile(configFileData.CaCertPath, []byte(rootCACert), 0644)
+	if err != nil {
+		return fmt.Errorf("cannot write root CA cert: %v", err)
+	}
+	err = os.MkdirAll(filepath.Dir(configFileData.CertPath), 0644)
+	if err != nil {
+		return fmt.Errorf("cannot create directory to place server cert: %v", err)
+	}
+	err = ioutil.WriteFile(configFileData.CertPath, []byte(cert), 0644)
+	if err != nil {
+		return fmt.Errorf("cannot write server cert: %v", err)
+	}
+	err = os.MkdirAll(filepath.Dir(configFileData.KeyPath), 0644)
+	if err != nil {
+		return fmt.Errorf("cannot create directory to place server key: %v", err)
+	}
+	err = ioutil.WriteFile(configFileData.KeyPath, []byte(key), 0600)
+	if err != nil {
+		return fmt.Errorf("cannot write server key: %v", err)
+	}
+	err = os.MkdirAll(config.ConfLocation, 0644)
+	if err != nil {
+		return fmt.Errorf("cannot create directory to place config file: %v", err)
+	}
+	f, err := os.OpenFile(config.ConfFile, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0644)
+	if err != nil {
+		return fmt.Errorf("Could not open config file for writing: %v", err)
+	}
+	defer f.Close()
+	err = configFileTemplate.Execute(f, configFileData)
+	if err != nil {
+		return fmt.Errorf("Could not generate config file contents: %v", err)
+	}
+	return nil
+}

--- a/cmdpolling/register.go
+++ b/cmdpolling/register.go
@@ -114,16 +114,16 @@ func configureServerKeys(config *utils.Config, rootCACert, cert, key string) err
 		configFileData.LogLevel = "info"
 	}
 	if configFileData.LogFile == "" {
-		configFileData.LogFile = utils.GetConfigFilePath("LogFile")
+		configFileData.LogFile = utils.GetDefaultLogFilePath()
 	}
 	if configFileData.CaCertPath == "" {
-		configFileData.CaCertPath = utils.GetConfigFilePath("CaCertPath")
+		configFileData.CaCertPath = utils.GetDefaultCaCertFilePath()
 	}
 	if configFileData.CertPath == "" {
-		configFileData.CertPath = utils.GetConfigFilePath("CertPath")
+		configFileData.CertPath = utils.GetDefaultCertFilePath()
 	}
 	if configFileData.KeyPath == "" {
-		configFileData.KeyPath = utils.GetConfigFilePath("KeyPath")
+		configFileData.KeyPath = utils.GetDefaultKeyFilePath()
 	}
 	err := os.MkdirAll(filepath.Dir(configFileData.CaCertPath), 0644)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ingrammicro/concerto/cloud/ssh_profiles"
 	"github.com/ingrammicro/concerto/cloud/workspaces"
 	"github.com/ingrammicro/concerto/cluster"
+	"github.com/ingrammicro/concerto/cmdpolling"
 	"github.com/ingrammicro/concerto/converge"
 	"github.com/ingrammicro/concerto/dispatcher"
 	"github.com/ingrammicro/concerto/dns"
@@ -65,6 +66,13 @@ var ServerCommands = []cli.Command{
 		Usage: "Manages registration and configuration within an imported brownfield Host",
 		Subcommands: append(
 			brownfield.SubCommands(),
+		),
+	},
+	{
+		Name:  "polling",
+		Usage: "Manages polling commands",
+		Subcommands: append(
+			cmdpolling.SubCommands(),
 		),
 	},
 }
@@ -349,7 +357,7 @@ func prepareFlags(c *cli.Context) error {
 	}
 	format.InitializeFormatter(c.String("formatter"), os.Stdout)
 
-	if config.IsHost || config.BrownfieldToken != "" {
+	if config.IsHost || config.BrownfieldToken != "" || (config.CommandPollingToken != "" && config.ServerID != "") {
 		log.Debug("Setting server commands to concerto")
 		c.App.Commands = ServerCommands
 	} else {
@@ -426,6 +434,16 @@ func main() {
 			EnvVar: "CONCERTO_BROWNFIELD_TOKEN",
 			Name:   "concerto-brownfield-token",
 			Usage:  "Concerto Brownfield Token",
+		},
+		cli.StringFlag{
+			EnvVar: "CONCERTO_COMMAND_POLLING_TOKEN",
+			Name:   "concerto-command-polling-token",
+			Usage:  "Concerto Command Polling Token",
+		},
+		cli.StringFlag{
+			EnvVar: "CONCERTO_SERVER_ID",
+			Name:   "concerto-server-id",
+			Usage:  "Concerto Server ID",
 		},
 		cli.StringFlag{
 			EnvVar: "CONCERTO_FORMATTER",

--- a/main.go
+++ b/main.go
@@ -357,7 +357,7 @@ func prepareFlags(c *cli.Context) error {
 	}
 	format.InitializeFormatter(c.String("formatter"), os.Stdout)
 
-	if config.IsHost || config.BrownfieldToken != "" || (config.CommandPollingToken != "" && config.ServerID != "") {
+	if config.IsHost || config.BrownfieldToken != "" || config.CommandPollingToken != "" {
 		log.Debug("Setting server commands to concerto")
 		c.App.Commands = ServerCommands
 	} else {

--- a/utils/config.go
+++ b/utils/config.go
@@ -442,35 +442,42 @@ func (config *Config) evaluateCertificate() error {
 	return nil
 }
 
-// GetConfigFilePath returns concerto configuration path file
-func GetConfigFilePath(fileFilter string) string {
-	log.Debug("GetConfigFilePath")
-	path := ""
-	switch {
-	case fileFilter == "LogFile":
-		if runtime.GOOS == "windows" {
-			path = windowsServerLogFilePath
-		} else {
-			path = nixServerLogFilePath
-		}
-	case fileFilter == "CaCertPath":
-		if runtime.GOOS == "windows" {
-			path = windowsServerCaCertPath
-		} else {
-			path = nixServerCaCertPath
-		}
-	case fileFilter == "CertPath":
-		if runtime.GOOS == "windows" {
-			path = windowsServerCertPath
-		} else {
-			path = nixServerCertPath
-		}
-	case fileFilter == "KeyPath":
-		if runtime.GOOS == "windows" {
-			path = windowsServerKeyPath
-		} else {
-			path = nixServerKeyPath
-		}
+// GetDefaultLogFilePath returns default concerto configuration path file
+func GetDefaultLogFilePath() (path string) {
+	if runtime.GOOS == "windows" {
+		path = windowsServerLogFilePath
+	} else {
+		path = nixServerLogFilePath
 	}
-	return path
+	return
+}
+
+// GetDefaultCaCertFilePath returns default concerto configuration path file
+func GetDefaultCaCertFilePath() (path string) {
+	if runtime.GOOS == "windows" {
+		path = windowsServerCaCertPath
+	} else {
+		path = nixServerCaCertPath
+	}
+	return
+}
+
+// GetDefaultCertFilePath returns default concerto configuration path file
+func GetDefaultCertFilePath() (path string) {
+	if runtime.GOOS == "windows" {
+		path = windowsServerCertPath
+	} else {
+		path = nixServerCertPath
+	}
+	return
+}
+
+// GetDefaultKeyFilePath returns default concerto configuration path file
+func GetDefaultKeyFilePath() (path string) {
+	if runtime.GOOS == "windows" {
+		path = windowsServerKeyPath
+	} else {
+		path = nixServerKeyPath
+	}
+	return
 }

--- a/utils/config.go
+++ b/utils/config.go
@@ -443,41 +443,33 @@ func (config *Config) evaluateCertificate() error {
 }
 
 // GetDefaultLogFilePath returns default concerto configuration path file
-func GetDefaultLogFilePath() (path string) {
+func GetDefaultLogFilePath() string {
 	if runtime.GOOS == "windows" {
-		path = windowsServerLogFilePath
-	} else {
-		path = nixServerLogFilePath
+		return windowsServerLogFilePath
 	}
-	return
+	return nixServerLogFilePath
 }
 
 // GetDefaultCaCertFilePath returns default concerto configuration path file
-func GetDefaultCaCertFilePath() (path string) {
+func GetDefaultCaCertFilePath() string {
 	if runtime.GOOS == "windows" {
-		path = windowsServerCaCertPath
-	} else {
-		path = nixServerCaCertPath
+		return windowsServerCaCertPath
 	}
-	return
+	return nixServerCaCertPath
 }
 
 // GetDefaultCertFilePath returns default concerto configuration path file
-func GetDefaultCertFilePath() (path string) {
+func GetDefaultCertFilePath() string {
 	if runtime.GOOS == "windows" {
-		path = windowsServerCertPath
-	} else {
-		path = nixServerCertPath
+		return windowsServerCertPath
 	}
-	return
+	return nixServerCertPath
 }
 
 // GetDefaultKeyFilePath returns default concerto configuration path file
-func GetDefaultKeyFilePath() (path string) {
+func GetDefaultKeyFilePath() string {
 	if runtime.GOOS == "windows" {
-		path = windowsServerKeyPath
-	} else {
-		path = nixServerKeyPath
+		return windowsServerKeyPath
 	}
-	return
+	return nixServerKeyPath
 }

--- a/utils/config.go
+++ b/utils/config.go
@@ -24,19 +24,30 @@ const windowsServerConfigFile = "c:\\concerto\\client.xml"
 const nixServerConfigFile = "/etc/concerto/client.xml"
 const defaultConcertoEndpoint = "https://clients.concerto.io:886/"
 
+const windowsServerLogFilePath = "c:\\concerto\\log\\concerto-client.log"
+const windowsServerCaCertPath = "c:\\concerto\\client_ssl\\ca_cert.pem"
+const windowsServerCertPath = "c:\\concerto\\client_ssl\\cert.pem"
+const windowsServerKeyPath = "c:\\concerto\\client_ssl\\private\\key.pem"
+const nixServerLogFilePath = "/var/log/concerto-client.log"
+const nixServerCaCertPath = "/etc/concerto/client_ssl/ca_cert.pem"
+const nixServerCertPath = "/etc/concerto/client_ssl/cert.pem"
+const nixServerKeyPath = "/etc/concerto/client_ssl/private/key.pem"
+
 // Config stores configuration file contents
 type Config struct {
-	XMLName            xml.Name `xml:"concerto"`
-	APIEndpoint        string   `xml:"server,attr"`
-	LogFile            string   `xml:"log_file,attr"`
-	LogLevel           string   `xml:"log_level,attr"`
-	Certificate        Cert     `xml:"ssl"`
-	ConfLocation       string
-	ConfFile           string
-	IsHost             bool
-	ConcertoURL        string
-	BrownfieldToken    string
-	CurrentUserIsAdmin bool
+	XMLName             xml.Name `xml:"concerto"`
+	APIEndpoint         string   `xml:"server,attr"`
+	LogFile             string   `xml:"log_file,attr"`
+	LogLevel            string   `xml:"log_level,attr"`
+	Certificate         Cert     `xml:"ssl"`
+	ConfLocation        string
+	ConfFile            string
+	IsHost              bool
+	ConcertoURL         string
+	BrownfieldToken     string
+	CommandPollingToken string
+	ServerID            string
+	CurrentUserIsAdmin  bool
 }
 
 // Cert stores cert files location
@@ -66,6 +77,11 @@ func InitializeConcertoConfig(c *cli.Context) (*Config, error) {
 	cachedConfig = &Config{}
 
 	err := cachedConfig.readBrownfieldToken(c)
+	if err != nil {
+		return nil, err
+	}
+
+	err = cachedConfig.readCommandPollingConfig(c)
 	if err != nil {
 		return nil, err
 	}
@@ -165,6 +181,17 @@ func (config *Config) IsConfigReadyBrownfield() bool {
 	return true
 }
 
+// IsConfigReadyCommandPolling returns whether config is ready for polling token
+// authentication
+func (config *Config) IsConfigReadyCommandPolling() bool {
+	if config.APIEndpoint == "" ||
+		config.CommandPollingToken == "" ||
+		config.ServerID == "" {
+		return false
+	}
+	return true
+}
+
 // readConcertoConfig reads Concerto config file located at fileLocation
 func (config *Config) readConcertoConfig(c *cli.Context) error {
 	log.Debug("Reading Concerto Configuration")
@@ -257,7 +284,7 @@ func (config *Config) evaluateConcertoConfigFile(c *cli.Context) error {
 	} else {
 
 		if runtime.GOOS == "windows" {
-			if config.CurrentUserIsAdmin && (config.BrownfieldToken != "" || FileExists(windowsServerConfigFile)) {
+			if config.CurrentUserIsAdmin && (config.BrownfieldToken != "" || (config.CommandPollingToken != "" && config.ServerID != "") || FileExists(windowsServerConfigFile)) {
 				log.Debug("Current user is administrator, setting config file as %s", windowsServerConfigFile)
 				config.ConfFile = windowsServerConfigFile
 			} else {
@@ -267,7 +294,7 @@ func (config *Config) evaluateConcertoConfigFile(c *cli.Context) error {
 			}
 		} else {
 			// Server mode *nix
-			if config.CurrentUserIsAdmin && (config.BrownfieldToken != "" || FileExists(nixServerConfigFile)) {
+			if config.CurrentUserIsAdmin && (config.BrownfieldToken != "" || (config.CommandPollingToken != "" && config.ServerID != "") || FileExists(nixServerConfigFile)) {
 				config.ConfFile = nixServerConfigFile
 			} else {
 				// User mode *nix
@@ -363,6 +390,25 @@ func (config *Config) readBrownfieldToken(c *cli.Context) error {
 	return nil
 }
 
+func (config *Config) readCommandPollingConfig(c *cli.Context) error {
+	if config.CommandPollingToken != "" || config.ServerID != "" {
+		return nil
+	}
+
+	// overwrite with environment/arguments vars
+	if overwCommandPollingToken := c.String("concerto-command-polling-token"); overwCommandPollingToken != "" {
+		log.Debug("Concerto Command Polling token taken from env/args")
+		config.CommandPollingToken = overwCommandPollingToken
+	}
+
+	if overwServerID := c.String("concerto-server-id"); overwServerID != "" {
+		log.Debug("Concerto Server ID taken from env/args")
+		config.ServerID = overwServerID
+	}
+
+	return nil
+}
+
 // evaluateCertificate determines if a certificate has been issued for a host
 func (config *Config) evaluateCertificate() error {
 
@@ -394,4 +440,37 @@ func (config *Config) evaluateCertificate() error {
 	}
 	config.IsHost = false
 	return nil
+}
+
+// GetConfigFilePath returns concerto configuration path file
+func GetConfigFilePath(fileFilter string) string {
+	log.Debug("GetConfigFilePath")
+	path := ""
+	switch {
+	case fileFilter == "LogFile":
+		if runtime.GOOS == "windows" {
+			path = windowsServerLogFilePath
+		} else {
+			path = nixServerLogFilePath
+		}
+	case fileFilter == "CaCertPath":
+		if runtime.GOOS == "windows" {
+			path = windowsServerCaCertPath
+		} else {
+			path = nixServerCaCertPath
+		}
+	case fileFilter == "CertPath":
+		if runtime.GOOS == "windows" {
+			path = windowsServerCertPath
+		} else {
+			path = nixServerCertPath
+		}
+	case fileFilter == "KeyPath":
+		if runtime.GOOS == "windows" {
+			path = windowsServerKeyPath
+		} else {
+			path = nixServerKeyPath
+		}
+	}
+	return path
 }


### PR DESCRIPTION
Implements a register subcommand to install server credentials using command-polling token and ServerID.

Tested in Windows 8.1 and Linux Mint 18.1 environments 