### PR TITLE
Implement subcommand Continuous Report Run (issue #14)

### DIFF
--- a/api/polling/polling_api.go
+++ b/api/polling/polling_api.go
@@ -72,3 +72,20 @@ func (p *PollingService) UpdateCommand(pollingCommandVector *map[string]interfac
 
 	return command, status, nil
 }
+
+// ReportBootstrapLog reports a command result
+func (p *PollingService) ReportBootstrapLog(PollingContinuousReportVector *map[string]interface{}) (command *types.PollingContinuousReport, status int, err error) {
+	log.Debug("ReportBootstrapLog")
+
+	payload := make(map[string]interface{})
+	data, status, err := p.concertoService.Post("/command_polling/bootstrap_logs", &payload)
+	if err != nil {
+		return nil, status, err
+	}
+
+	if err = json.Unmarshal(data, &command); err != nil {
+		return nil, status, err
+	}
+
+	return command, status, nil
+}

--- a/api/polling/polling_api.go
+++ b/api/polling/polling_api.go
@@ -77,8 +77,7 @@ func (p *PollingService) UpdateCommand(pollingCommandVector *map[string]interfac
 func (p *PollingService) ReportBootstrapLog(PollingContinuousReportVector *map[string]interface{}) (command *types.PollingContinuousReport, status int, err error) {
 	log.Debug("ReportBootstrapLog")
 
-	payload := make(map[string]interface{})
-	data, status, err := p.concertoService.Post("/command_polling/bootstrap_logs", &payload)
+	data, status, err := p.concertoService.Post("/command_polling/bootstrap_logs", PollingContinuousReportVector)
 	if err != nil {
 		return nil, status, err
 	}

--- a/api/polling/polling_api_mocked.go
+++ b/api/polling/polling_api_mocked.go
@@ -341,3 +341,116 @@ func UpdateCommandFailJSONMocked(t *testing.T, commandIn *types.PollingCommand) 
 
 	return commandOut
 }
+
+
+// ReportBootstrapLogMocked test mocked function
+func ReportBootstrapLogMocked(t *testing.T, commandIn *types.PollingContinuousReport) *types.PollingContinuousReport {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewPollingService(cs)
+	assert.Nil(err, "Couldn't load polling service")
+	assert.NotNil(ds, "Polling service not instanced")
+
+	// to json
+	dOut, err := json.Marshal(commandIn)
+	assert.Nil(err, "ReportBootstrapLog test data corrupted")
+
+	// call service
+	payload := make(map[string]interface{})
+	cs.On("Post", fmt.Sprintf("/command_polling/bootstrap_logs"), &payload).Return(dOut, 201, nil)
+	commandOut, status, err := ds.ReportBootstrapLog(&payload)
+
+	assert.Nil(err, "Error posting report command")
+	assert.Equal(status, 201, "ReportBootstrapLog returned invalid response")
+	assert.Equal(commandOut.Stdout, "Bootstrap log created", "ReportBootstrapLog returned unexpected message")
+
+	return commandOut
+}
+
+// ReportBootstrapLogFailErrMocked test mocked function
+func ReportBootstrapLogFailErrMocked(t *testing.T, commandIn *types.PollingContinuousReport) *types.PollingContinuousReport {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewPollingService(cs)
+	assert.Nil(err, "Couldn't load polling service")
+	assert.NotNil(ds, "Polling service not instanced")
+
+	// to json
+	dIn, err := json.Marshal(commandIn)
+	assert.Nil(err, "ReportBootstrapLog test data corrupted")
+
+	dIn = nil
+
+	// call service
+	payload := make(map[string]interface{})
+	cs.On("Post", fmt.Sprintf("/command_polling/bootstrap_logs"), &payload).Return(dIn, 400, fmt.Errorf("Mocked error"))
+	commandOut, _, err := ds.ReportBootstrapLog(&payload)
+
+	assert.NotNil(err, "We are expecting an error")
+	assert.Nil(commandOut, "Expecting nil output")
+	assert.Equal(err.Error(), "Mocked error", "Error should be 'Mocked error'")
+
+	return commandOut
+}
+
+// ReportBootstrapLogFailStatusMocked test mocked function
+func ReportBootstrapLogFailStatusMocked(t *testing.T, commandIn *types.PollingContinuousReport) *types.PollingContinuousReport {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewPollingService(cs)
+	assert.Nil(err, "Couldn't load polling service")
+	assert.NotNil(ds, "Polling service not instanced")
+
+	// to json
+	dIn, err := json.Marshal(commandIn)
+	assert.Nil(err, "ReportBootstrapLog test data corrupted")
+
+	dIn = nil
+
+	// call service
+	payload := make(map[string]interface{})
+	cs.On("Post", fmt.Sprintf("/command_polling/bootstrap_logs"), &payload).Return(dIn, 499, fmt.Errorf("Error 499 Mocked error"))
+	commandOut, status, err := ds.ReportBootstrapLog(&payload)
+
+	assert.Equal(status, 499, "ReportBootstrapLog returned an unexpected status code")
+	assert.NotNil(err, "We are expecting a status code error")
+	assert.Nil(commandOut, "Expecting nil output")
+	assert.Contains(err.Error(), "499", "Error should contain http code 499")
+
+	return commandOut
+}
+
+// ReportBootstrapLogFailJSONMocked test mocked function
+func ReportBootstrapLogFailJSONMocked(t *testing.T, commandIn *types.PollingContinuousReport) *types.PollingContinuousReport {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewPollingService(cs)
+	assert.Nil(err, "Couldn't load polling service")
+	assert.NotNil(ds, "Polling service not instanced")
+
+	// wrong json
+	dIn := []byte{10, 20, 30}
+
+	// call service
+	payload := make(map[string]interface{})
+	cs.On("Post", fmt.Sprintf("/command_polling/bootstrap_logs"), &payload).Return(dIn, 201, nil)
+	commandOut, _, err := ds.ReportBootstrapLog(&payload)
+
+	assert.NotNil(err, "We are expecting a marshalling error")
+	assert.Nil(commandOut, "Expecting nil output")
+	assert.Contains(err.Error(), "invalid character", "Error message should include the string 'invalid character'")
+
+	return commandOut
+}

--- a/api/polling/polling_api_test.go
+++ b/api/polling/polling_api_test.go
@@ -36,3 +36,12 @@ func TestUpdateCommand(t *testing.T) {
 	UpdateCommandFailStatusMocked(t, commandIn)
 	UpdateCommandFailJSONMocked(t, commandIn)
 }
+
+
+func TestReportBootstrapLog(t *testing.T) {
+	commandIn := testdata.GetPollingContinuousReportData()
+	ReportBootstrapLogMocked(t, commandIn)
+	ReportBootstrapLogFailErrMocked(t, commandIn)
+	ReportBootstrapLogFailStatusMocked(t, commandIn)
+	ReportBootstrapLogFailJSONMocked(t, commandIn)
+}

--- a/api/types/polling_continuous_report.go
+++ b/api/types/polling_continuous_report.go
@@ -1,0 +1,5 @@
+package types
+
+type PollingContinuousReport struct {
+	Stdout string `json:"stdout" header:"STDOUT"`
+}

--- a/cmdpolling/continuousreport.go
+++ b/cmdpolling/continuousreport.go
@@ -1,19 +1,12 @@
 package cmdpolling
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
-	"io/ioutil"
-	"os"
-	"os/exec"
-	"runtime"
-	"strings"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
-	"github.com/ingrammicro/concerto/api/polling"
 	"github.com/ingrammicro/concerto/api/types"
 	"github.com/ingrammicro/concerto/cmd"
 	"github.com/ingrammicro/concerto/utils"
@@ -21,18 +14,9 @@ import (
 )
 
 const (
-	DefaultThresholdLines = 10
-	DefaultThresholdTime  = 10
-	DefaultThresholdBytes = 500
-	RetriesNumber         = 5
-	RetriesFactor         = 3
+	RetriesNumber = 5
+	RetriesFactor = 3
 )
-
-type Threshold struct {
-	lines int
-	time  int
-	bytes int
-}
 
 func cmdContinuousReportRun(c *cli.Context) error {
 	log.Debug("cmdContinuousReportRun")
@@ -49,104 +33,47 @@ func cmdContinuousReportRun(c *cli.Context) error {
 	}
 
 	// cli command thresholds flags
-	thresholdLines := c.Int("lines")
-	if !(thresholdLines > 0) {
-		thresholdLines = DefaultThresholdLines
-	}
-	thresholdTime := c.Int("time")
-	if !(thresholdTime > 0) {
-		thresholdTime = DefaultThresholdTime
-	}
-	thresholdBytes := c.Int("bytes")
-	if !(thresholdBytes > 0) {
-		thresholdBytes = DefaultThresholdBytes
-	}
-	threshold := Threshold{lines: thresholdLines, time: thresholdTime, bytes: thresholdBytes}
-	log.Debug("Threshold", threshold)
+	thresholds := utils.Thresholds{Lines: c.Int("lines"), Time: c.Int("time"), Bytes: c.Int("bytes")}
 
-	if err := processCommand(pollingSvc, cmdArg, threshold); err != nil {
+	// Custom method for chunks processing
+	fn := func(chunk string) error {
+		log.Debug("sendChunks")
+
+		err := retry(RetriesNumber, time.Second, func() error {
+			log.Debug("Sending: ", chunk)
+			command := types.PollingContinuousReport{
+				Stdout: chunk,
+			}
+			commandIn, err := utils.ItemConvertParamsWithTagAsID(command)
+			if err != nil {
+				return fmt.Errorf("error parsing payload %v", err)
+			}
+
+			_, statusCode, err := pollingSvc.ReportBootstrapLog(commandIn)
+			switch {
+			// 0<100 error cases??
+			case statusCode == 0:
+				return fmt.Errorf("communication error %v %v", statusCode, err)
+			case statusCode >= 500:
+				return fmt.Errorf("server error %v %v", statusCode, err)
+			case statusCode >= 400:
+				return fmt.Errorf("client error %v %v", statusCode, err)
+			default:
+				return nil
+			}
+		})
+
+		if err != nil {
+			return fmt.Errorf("cannot send the chunk data, %v", err)
+		}
+		return nil
+	}
+
+	if err := utils.RunContinuousReportRun(fn, cmdArg, thresholds); err != nil {
 		formatter.PrintFatal("cannot process continuous report command", err)
 	}
 
 	log.Info("completed")
-	return nil
-}
-
-func processCommand(pollingSvc *polling.PollingService, cmdArg string, threshold Threshold) error {
-	log.Debug("processCommand")
-
-	// Saves script/command in a temp file
-	cmdFileName := strings.Join([]string{time.Now().Format("20060102150405"), "_", utils.RandomString(10)}, "")
-	if runtime.GOOS == "windows" {
-		cmdFileName = strings.Join([]string{cmdFileName, ".bat"}, "")
-	}
-
-	// Writes content
-	if err := ioutil.WriteFile(cmdFileName, []byte(cmdArg), 0600); err != nil {
-		log.Fatalf("Error creating temp file : ", err)
-	}
-
-	// Creates command
-	var newCmd *exec.Cmd
-	if runtime.GOOS == "windows" {
-		newCmd = exec.Command("cmd", "/C", cmdFileName)
-	} else {
-		newCmd = exec.Command("/bin/sh", cmdFileName)
-	}
-
-	// Removes temp file
-	defer func() {
-		err := os.Remove(cmdFileName)
-		if err != nil {
-			log.Warn("Temp file cannot be removed", err.Error())
-		}
-	}()
-
-	// Gets the pipe command
-	stdout, err := newCmd.StdoutPipe()
-	if err != nil {
-		return fmt.Errorf("cannot get pipe command %v", err)
-	}
-	log.Info("==> Executing: ", strings.Join(newCmd.Args, " "))
-
-	// Start command asynchronously
-	if err = newCmd.Start(); err != nil {
-		return fmt.Errorf("cannot start the specified command %v", err)
-	}
-
-	chunk := ""
-	nLines, nTime, nBytes := 0, 0, 0
-	timeStart := time.Now()
-
-	scanner := bufio.NewScanner(bufio.NewReader(stdout))
-	for scanner.Scan() {
-		chunk = strings.Join([]string{chunk, scanner.Text(), "\n"}, "")
-		nLines++
-		nTime = int(time.Now().Sub(timeStart).Seconds())
-		nBytes = len(chunk)
-		if nLines >= threshold.lines || nTime >= threshold.time || nBytes >= threshold.bytes {
-			if err := sendChunks(pollingSvc, chunk); err != nil {
-				nLines, nTime = 0, 0
-				timeStart = time.Now()
-			} else {
-				chunk = ""
-				nLines, nTime, nBytes = 0, 0, 0
-				timeStart = time.Now()
-			}
-		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		log.Error("==> Error: ", err.Error())
-		chunk = strings.Join([]string{chunk, err.Error()}, "")
-	}
-
-	if len(chunk) > 0 {
-		log.Debug("Sending the last pending chunk")
-		if err := sendChunks(pollingSvc, chunk); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 
@@ -160,38 +87,6 @@ func retry(attempts int, sleep time.Duration, fn func() error) error {
 			return retry(attempts, RetriesFactor*sleep, fn)
 		}
 		return err
-	}
-	return nil
-}
-
-func sendChunks(pollingSvc *polling.PollingService, chunk string) error {
-	log.Debug("sendChunks")
-
-	err := retry(RetriesNumber, time.Second, func() error {
-		log.Debug("Sending: ", chunk)
-		command := types.PollingContinuousReport{
-			Stdout: chunk,
-		}
-		commandIn, err := utils.ItemConvertParamsWithTagAsID(command)
-		if err != nil {
-			return fmt.Errorf("error parsing payload %v", err)
-		}
-
-		_, statusCode, err := pollingSvc.ReportBootstrapLog(commandIn)
-		switch {
-		case statusCode == 0:
-			return fmt.Errorf("communication error %v %v", statusCode, err)
-		case statusCode >= 500:
-			return fmt.Errorf("server error %v %v", statusCode, err)
-		case statusCode >= 400:
-			return fmt.Errorf("client error %v %v", statusCode, err)
-		default:
-			return nil
-		}
-	})
-
-	if err != nil {
-		return fmt.Errorf("cannot send the chunk data, %v", err)
 	}
 	return nil
 }

--- a/cmdpolling/continuousreport.go
+++ b/cmdpolling/continuousreport.go
@@ -1,0 +1,176 @@
+package cmdpolling
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/codegangsta/cli"
+	"github.com/ingrammicro/concerto/api/polling"
+	"github.com/ingrammicro/concerto/api/types"
+	"github.com/ingrammicro/concerto/cmd"
+	"github.com/ingrammicro/concerto/utils"
+	"github.com/ingrammicro/concerto/utils/format"
+)
+
+const (
+	DefaultThresholdLines = 10
+	DefaultThresholdTime  = 10
+	DefaultThresholdBytes = 500
+	RetriesNumber         = 5
+	RetriesFactor         = 3
+)
+
+type Threshold struct {
+	lines int
+	time  int
+	bytes int
+}
+
+func cmdContinuousReportRun(c *cli.Context) error {
+	log.Debug("cmdContinuousReportRun")
+
+	formatter := format.GetFormatter()
+	pollingSvc := cmd.WireUpPolling(c)
+
+	// cli command argument
+	var commandArg string
+	if c.Args().Present() {
+		commandArg = c.Args().First()
+	} else {
+		formatter.PrintFatal("argument missing", errors.New("a script or command is required"))
+	}
+
+	// cli command thresholds flags
+	thresholdLines := c.Int("lines")
+	if !(thresholdLines > 0) {
+		thresholdLines = DefaultThresholdLines
+	}
+	thresholdTime := c.Int("time")
+	if !(thresholdTime > 0) {
+		thresholdTime = DefaultThresholdTime
+	}
+	thresholdBytes := c.Int("bytes")
+	if !(thresholdBytes > 0) {
+		thresholdBytes = DefaultThresholdBytes
+	}
+	threshold := Threshold{lines: thresholdLines, time: thresholdTime, bytes: thresholdBytes}
+	log.Debug("Threshold", threshold)
+
+	if err := processCommand(pollingSvc, commandArg, threshold); err != nil {
+		formatter.PrintFatal("cannot process continuous report command", err)
+	}
+
+	log.Info("completed")
+	return nil
+}
+
+func processCommand(pollingSvc *polling.PollingService, commandArg string, threshold Threshold) error {
+	log.Debug("processCommand")
+
+	var newCmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		newCmd = exec.Command("cmd", "/C", commandArg)
+	} else {
+		newCmd = exec.Command("/bin/sh", "-c", commandArg)
+	}
+
+	// Gets the pipe command
+	stdout, err := newCmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("cannot get pipe command %v", err)
+	}
+	log.Info("==> Executing: ", strings.Join(newCmd.Args, " "))
+
+	// Start command asynchronously
+	if err = newCmd.Start(); err != nil {
+		return fmt.Errorf("cannot start the specified command %v", err)
+	}
+
+	line := ""
+	nLines, nTime, nBytes := 0, 0, 0
+	timeStart := time.Now()
+
+	scanner := bufio.NewScanner(bufio.NewReader(stdout))
+	for scanner.Scan() {
+		line += scanner.Text()
+		if len(line) > 0 {
+			nLines++
+			nTime = int(time.Now().Sub(timeStart).Seconds())
+			nBytes = len(line)
+			if nLines >= threshold.lines || nTime >= threshold.time || nBytes >= threshold.bytes {
+				if err := sendChunks(pollingSvc, line); err != nil {
+					return err
+				} else {
+					line = ""
+					nLines, nTime, nBytes = 0, 0, 0
+					timeStart = time.Now()
+				}
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		log.Error("==> Error: ", err.Error())
+		if err := sendChunks(pollingSvc, "error reading standard input:"+err.Error()); err != nil {
+			return err
+		}
+	} else {
+		log.Debug("Sending the last pending chunk")
+		if err := sendChunks(pollingSvc, line); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func retry(attempts int, sleep time.Duration, fn func() error) error {
+	log.Debug("retry")
+
+	if err := fn(); err != nil {
+		if attempts--; attempts > 0 {
+			log.Debug("Waiting to retry: ", sleep)
+			time.Sleep(sleep)
+			return retry(attempts, RetriesFactor*sleep, fn)
+		}
+		return err
+	}
+	return nil
+}
+
+func sendChunks(pollingSvc *polling.PollingService, chunk string) error {
+	log.Debug("sendChunks")
+
+	err := retry(RetriesNumber, time.Second, func() error {
+		log.Debug("Sending: ", chunk)
+		command := types.PollingContinuousReport{
+			Stdout: chunk,
+		}
+		commandIn, err := utils.ItemConvertParamsWithTagAsID(command)
+		if err != nil {
+			return fmt.Errorf("error parsing payload %v", err)
+		}
+
+		_, statusCode, err := pollingSvc.ReportBootstrapLog(commandIn)
+		switch {
+		case statusCode == 0:
+			return fmt.Errorf("communication error %v %v", statusCode, err)
+		case statusCode >= 500:
+			return fmt.Errorf("server error %v %v", statusCode, err)
+		case statusCode >= 400:
+			return fmt.Errorf("client error %v %v", statusCode, err)
+		default:
+			return nil
+		}
+	})
+
+	if err != nil {
+		return fmt.Errorf("cannot send the chunk data, %v", err)
+	}
+	return nil
+}

--- a/cmdpolling/polling.go
+++ b/cmdpolling/polling.go
@@ -7,6 +7,7 @@ import (
 	"syscall"
 	"time"
 	"encoding/json"
+	"strings"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
@@ -35,12 +36,17 @@ func handleSysSignals(cancelFunc context.CancelFunc) {
 	cancelFunc()
 }
 
+// Returns the full path to the tmp folder joined with pid management file name
+func getProcessIdFilePath() string{
+	return strings.Join([]string{os.TempDir(),  string(os.PathSeparator), ProcessIdFile}, "")
+}
+
 // Start the polling process
 func cmdStart(c *cli.Context) error {
 	log.Debug("cmdStart")
 
 	formatter := format.GetFormatter()
-	if err := utils.SetProcessIdToFile(ProcessIdFile); err != nil {
+	if err := utils.SetProcessIdToFile(getProcessIdFilePath()); err != nil {
 		formatter.PrintFatal("cannot create the pid file", err)
 	}
 
@@ -65,7 +71,7 @@ func cmdStop(c *cli.Context) error {
 	log.Debug("cmdStop")
 
 	formatter := format.GetFormatter()
-	if err := utils.StopProcess(ProcessIdFile); err != nil {
+	if err := utils.StopProcess(getProcessIdFilePath()); err != nil {
 		formatter.PrintFatal("cannot stop the polling process", err)
 	}
 

--- a/cmdpolling/subcommands.go
+++ b/cmdpolling/subcommands.go
@@ -28,5 +28,28 @@ func SubCommands() []cli.Command {
 			Usage:  "Stops the running polling process",
 			Action: cmdStop,
 		},
+		{
+			Name:   "continuous-report-run",
+			Usage:  "Runs a script and gradually report its output",
+			Action: cmdContinuousReportRun,
+			ArgsUsage: "script",
+			Flags: []cli.Flag{
+				cli.IntFlag{
+					Name:  "lines, l",
+					Usage: "Maximum lines threshold per response chunk",
+					Value: DefaultThresholdLines,
+				},
+				cli.IntFlag{
+					Name:  "time, t",
+					Usage: "Maximum time -seconds- threshold per response chunk",
+					Value: DefaultThresholdTime,
+				},
+				cli.IntFlag{
+					Name:  "bytes, b",
+					Usage: "Maximum bytes threshold per response chunk",
+					Value: DefaultThresholdBytes,
+				},
+			},
+		},
 	}
 }

--- a/cmdpolling/subcommands.go
+++ b/cmdpolling/subcommands.go
@@ -2,7 +2,6 @@ package cmdpolling
 
 import (
 	"github.com/codegangsta/cli"
-	"github.com/ingrammicro/concerto/utils"
 )
 
 func SubCommands() []cli.Command {
@@ -18,9 +17,14 @@ func SubCommands() []cli.Command {
 			Action: cmdStart,
 			Flags: []cli.Flag{
 				cli.Int64Flag{
-					Name:  "time, t",
-					Usage: "Polling ping time interval (seconds)",
-					Value: 30,
+					Name:  "longTime, l",
+					Usage: "Polling ping long time interval (seconds)",
+					Value: DefaultPollingPingTimingIntervalLong,
+				},
+				cli.Int64Flag{
+					Name:  "shortTime, s",
+					Usage: "Polling ping short time interval (seconds)",
+					Value: DefaultPollingPingTimingIntervalShort,
 				},
 			},
 		},
@@ -30,25 +34,15 @@ func SubCommands() []cli.Command {
 			Action: cmdStop,
 		},
 		{
-			Name:   "continuous-report-run",
-			Usage:  "Runs a script and gradually report its output",
-			Action: cmdContinuousReportRun,
+			Name:      "continuous-report-run",
+			Usage:     "Runs a script and gradually report its output",
+			Action:    cmdContinuousReportRun,
 			ArgsUsage: "script",
 			Flags: []cli.Flag{
 				cli.IntFlag{
-					Name:  "lines, l",
-					Usage: "Maximum lines threshold per response chunk",
-					Value: utils.DefaultThresholdLines,
-				},
-				cli.IntFlag{
 					Name:  "time, t",
 					Usage: "Maximum time -seconds- threshold per response chunk",
-					Value: utils.DefaultThresholdTime,
-				},
-				cli.IntFlag{
-					Name:  "bytes, b",
-					Usage: "Maximum bytes threshold per response chunk",
-					Value: utils.DefaultThresholdBytes,
+					Value: DefaultThresholdTime,
 				},
 			},
 		},

--- a/cmdpolling/subcommands.go
+++ b/cmdpolling/subcommands.go
@@ -2,6 +2,7 @@ package cmdpolling
 
 import (
 	"github.com/codegangsta/cli"
+	"github.com/ingrammicro/concerto/utils"
 )
 
 func SubCommands() []cli.Command {
@@ -37,17 +38,17 @@ func SubCommands() []cli.Command {
 				cli.IntFlag{
 					Name:  "lines, l",
 					Usage: "Maximum lines threshold per response chunk",
-					Value: DefaultThresholdLines,
+					Value: utils.DefaultThresholdLines,
 				},
 				cli.IntFlag{
 					Name:  "time, t",
 					Usage: "Maximum time -seconds- threshold per response chunk",
-					Value: DefaultThresholdTime,
+					Value: utils.DefaultThresholdTime,
 				},
 				cli.IntFlag{
 					Name:  "bytes, b",
 					Usage: "Maximum bytes threshold per response chunk",
-					Value: DefaultThresholdBytes,
+					Value: utils.DefaultThresholdBytes,
 				},
 			},
 		},

--- a/testdata/polling_data.go
+++ b/testdata/polling_data.go
@@ -27,3 +27,13 @@ func GetPollingCommandData() *types.PollingCommand {
 
 	return &testPollingCommand
 }
+
+// GetPollingContinuousReportData loads test data
+func GetPollingContinuousReportData() *types.PollingContinuousReport {
+
+	testPollingContinuousReport := types.PollingContinuousReport{
+		Stdout: "Bootstrap log created",
+	}
+
+	return &testPollingContinuousReport
+}

--- a/utils/cli_parameters.go
+++ b/utils/cli_parameters.go
@@ -69,18 +69,6 @@ func ItemConvertParams(item interface{}) (*map[string]interface{}, error) {
 	return &v, nil
 }
 
-// ItemConvertParamsWithTagAsID converts param items into map of interface with json tags
-func ItemConvertParamsWithTagAsID(item interface{}) (*map[string]interface{}, error) {
-	it := reflect.ValueOf(item)
-	nf := it.NumField()
-	v := make(map[string]interface{})
-
-	for i := 0; i < nf; i++ {
-		v[it.Type().Field(i).Tag.Get("json")] = fmt.Sprintf("%s", it.Field(i).Interface())
-	}
-	return &v, nil
-}
-
 // JSONParam parses parameter as json structure
 func JSONParam(param string) (interface{}, error) {
 	var p interface{}

--- a/utils/exec.go
+++ b/utils/exec.go
@@ -4,19 +4,31 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"runtime"
 	"strings"
 	"syscall"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 const (
-	TimeStampLayout = "2006-01-02T15:04:05.000000-07:00"
+	TimeStampLayout          = "2006-01-02T15:04:05.000000-07:00"
+	TimeLayoutYYYYMMDDHHMMSS = "20060102150405"
+	DefaultThresholdLines    = 10
+	DefaultThresholdTime     = 10
+	DefaultThresholdBytes    = 500
 )
+
+type Thresholds struct {
+	Lines int
+	Time  int
+	Bytes int
+}
 
 func extractExitCode(err error) int {
 	if err != nil {
@@ -134,4 +146,94 @@ func RunCmd(command string) (output string, exitCode int, startedAt time.Time, f
 	log.Debugf("")
 	log.Infof("Exit Code: %d", exitCode)
 	return
+}
+
+func RunContinuousReportRun(fn func(chunk string) error, cmdArg string, thresholds Thresholds) error {
+	log.Debug("RunContinuousReportRun")
+
+	// command thresholds flags
+	if !(thresholds.Lines > 0) {
+		thresholds.Lines = DefaultThresholdLines
+	}
+	if !(thresholds.Time > 0) {
+		thresholds.Time = DefaultThresholdTime
+	}
+	if !(thresholds.Bytes > 0) {
+		thresholds.Bytes = DefaultThresholdBytes
+	}
+	log.Debug("Threshold", thresholds)
+
+	// Saves script/command in a temp file
+	cmdFileName := strings.Join([]string{time.Now().Format(TimeLayoutYYYYMMDDHHMMSS), "_", RandomString(10)}, "")
+	if runtime.GOOS == "windows" {
+		cmdFileName = strings.Join([]string{cmdFileName, ".bat"}, "")
+	}
+
+	// Writes content
+	if err := ioutil.WriteFile(cmdFileName, []byte(cmdArg), 0600); err != nil {
+		log.Fatalf("Error creating temp file : ", err)
+	}
+
+	// Creates command
+	var newCmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		newCmd = exec.Command("cmd", "/C", cmdFileName)
+	} else {
+		newCmd = exec.Command("/bin/sh", cmdFileName)
+	}
+
+	// Removes temp file
+	defer func() {
+		err := os.Remove(cmdFileName)
+		if err != nil {
+			log.Warn("Temp file cannot be removed", err.Error())
+		}
+	}()
+
+	// Gets the pipe command
+	stdout, err := newCmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("cannot get pipe command %v", err)
+	}
+	log.Info("==> Executing: ", strings.Join(newCmd.Args, " "))
+
+	// Start command asynchronously
+	if err = newCmd.Start(); err != nil {
+		return fmt.Errorf("cannot start the specified command %v", err)
+	}
+
+	chunk := ""
+	nLines, nTime, nBytes := 0, 0, 0
+	timeStart := time.Now()
+
+	scanner := bufio.NewScanner(bufio.NewReader(stdout))
+	for scanner.Scan() {
+		chunk = strings.Join([]string{chunk, scanner.Text(), "\n"}, "")
+		nLines++
+		nTime = int(time.Now().Sub(timeStart).Seconds())
+		nBytes = len(chunk)
+		if nLines >= thresholds.Lines || nTime >= thresholds.Time || nBytes >= thresholds.Bytes {
+			if err := fn(chunk); err != nil {
+				nLines, nTime = 0, 0
+				timeStart = time.Now()
+			} else {
+				chunk = ""
+				nLines, nTime, nBytes = 0, 0, 0
+				timeStart = time.Now()
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		log.Error("==> Error: ", err.Error())
+		chunk = strings.Join([]string{chunk, err.Error()}, "")
+	}
+
+	if len(chunk) > 0 {
+		log.Debug("Sending the last pending chunk")
+		if err := fn(chunk); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -4,10 +4,12 @@ import (
 	"archive/zip"
 	"fmt"
 	"io"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/codegangsta/cli"
 
@@ -185,4 +187,14 @@ func CheckRequiredFlags(c *cli.Context, flags []string) {
 		cli.ShowCommandHelp(c, c.Command.Name)
 		os.Exit(2)
 	}
+}
+
+func RandomString(strlen int) string {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const chars = "abcdefghijklmnopqrstuvwxyz0123456789"
+	result := make([]byte, strlen)
+	for i := range result {
+		result[i] = chars[r.Intn(len(chars))]
+	}
+	return string(result)
 }


### PR DESCRIPTION
First proposal:
- The command recive a required argument, as a command or script
- Continous execution, run script and gradually report its output
- Thresholds configurable (per lines, time, bytes)
- Retry strategy while reporting output chunks

See #14