### PR TITLE
Deactivate windows firewall on instance booting

### DIFF
--- a/firewall/firewall.go
+++ b/firewall/firewall.go
@@ -85,6 +85,8 @@ func cmdApply(c *cli.Context) error {
 	// Only apply firewall if we get a non-empty set of rules
 	if len(policy.Rules) > 0 {
 		apply(policy)
+	} else {
+		flush()
 	}
 	return nil
 }


### PR DESCRIPTION
The firewall rules are applied by the IMCO platform; The firewall must be deactivated at the Windows machine level in order not to interfere in the monitoring.

Closes #19 