### PR TITLE
Ensure firewall flush in RHEL allows all traffic in (issue #79)

### DIFF
--- a/firewall/iptables.go
+++ b/firewall/iptables.go
@@ -4,6 +4,7 @@ package firewall
 
 import (
 	"fmt"
+	"os"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/ingrammicro/concerto/utils"
@@ -43,6 +44,9 @@ func apply(policy Policy) error {
 }
 
 func flush() error {
+	if _, err := os.Stat("/etc/redhat-release"); err == nil {
+		utils.RunCmd("firewall-cmd --set-default-zone=trusted")
+	}
 	utils.RunCmd("/sbin/iptables -w -P INPUT ACCEPT")
 	utils.RunCmd("/sbin/iptables -w -F CONCERTO")
 	utils.RunCmd("/sbin/iptables -w -D INPUT -j CONCERTO")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
Ensure running of `firewall-cmd --set-default-zone=trusted` on RHEL-like environments as part of firewall flush command

# Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#79 

# Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

# How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

# Screenshots (if appropriate)

# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.