### PR TITLE
Improve usability for composed parameters (issue #45)

### DIFF
--- a/api/types/apps.go
+++ b/api/types/apps.go
@@ -1,12 +1,8 @@
 package types
 
-import (
-	"encoding/json"
-)
-
 type WizardApp struct {
-	ID                  string          `json:"id" header:"ID"`
-	Name                string          `json:"name" header:"NAME"`
-	FlavourRequirements json.RawMessage `json:"flavour_requirements" header:"FLAVOUR_REQUIREMENTS"`
-	GenericImageID      string          `json:"generic_image_id" header:"GENERIC_IMAGE_ID"`
+	ID                  string                 `json:"id" header:"ID"`
+	Name                string                 `json:"name" header:"NAME"`
+	FlavourRequirements map[string]interface{} `json:"flavour_requirements" header:"FLAVOUR_REQUIREMENTS"`
+	GenericImageID      string                 `json:"generic_image_id" header:"GENERIC_IMAGE_ID"`
 }

--- a/api/types/bootstrapping.go
+++ b/api/types/bootstrapping.go
@@ -1,12 +1,8 @@
 package types
 
-import (
-	"encoding/json"
-)
-
 type BootstrappingConfiguration struct {
 	Policyfiles         []BootstrappingPolicyfile `json:"policyfiles,omitempty" header:"POLICY_FILES" show:"nolist"`
-	Attributes          *json.RawMessage          `json:"attributes,omitempty" header:"ATTRIBUTES" show:"nolist"`
+	Attributes          map[string]interface{}    `json:"attributes,omitempty" header:"ATTRIBUTES" show:"nolist"`
 	AttributeRevisionID string                    `json:"attribute_revision_id,omitempty" header:"ATTRIBUTE_REVISION_ID"`
 }
 

--- a/api/types/firewall_profiles.go
+++ b/api/types/firewall_profiles.go
@@ -1,5 +1,12 @@
 package types
 
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
 type FirewallProfile struct {
 	ID           string `json:"id" header:"ID"`
 	Name         string `json:"name,omitempty" header:"NAME"`
@@ -15,4 +22,45 @@ type Rule struct {
 	MinPort  int    `json:"min_port" header:"MIN_PORT"`
 	MaxPort  int    `json:"max_port" header:"MAX_PORT"`
 	CidrIP   string `json:"source" header:"SOURCE"`
+}
+
+// ConvertFlagParamsToRules converts received input rules parameters into a Firewall Profile rules array
+func (fp *FirewallProfile) ConvertFlagParamsToRules(rulesIn string) error {
+	compRegEx := regexp.MustCompile(`(?P<ip_protocol>\w{3})\/(?P<min_port>\d+)(?:-(?P<max_port>\d+)?)?:(?P<source>[a-zA-Z0-9.\/]+)`)
+	for _, r := range strings.Split(rulesIn, ",") {
+		values := compRegEx.FindStringSubmatch(r)
+		if len(values) == 0 {
+			return fmt.Errorf("invalid input rule format %s", r)
+		}
+		names := compRegEx.SubexpNames()
+		mapValueByName := make(map[string]string)
+		for j := range values {
+			if names[j] != "" {
+				mapValueByName[names[j]] = values[j]
+			}
+		}
+		rule := new(Rule)
+		// ip_protocol
+		rule.Protocol = strings.ToLower(mapValueByName["ip_protocol"])
+
+		// min_port
+		minPort, err := strconv.Atoi(mapValueByName["min_port"])
+		if err != nil {
+			return fmt.Errorf("invalid port %s, is not a valid format. %s", mapValueByName["min_port"], err)
+		}
+		rule.MinPort = minPort
+
+		// max_port
+		maxPort, err := strconv.Atoi(mapValueByName["max_port"])
+		if err != nil {
+			maxPort = minPort
+		}
+		rule.MaxPort = maxPort
+
+		// source/cidr
+		rule.CidrIP = strings.ToLower(mapValueByName["source"])
+
+		fp.Rules = append(fp.Rules, *rule)
+	}
+	return nil
 }

--- a/api/types/firewall_profiles.go
+++ b/api/types/firewall_profiles.go
@@ -24,15 +24,16 @@ type Rule struct {
 	CidrIP   string `json:"source" header:"SOURCE"`
 }
 
+var firewallProfileRulesRegexp = regexp.MustCompile(`(?P<ip_protocol>\w{3})\/(?P<min_port>\d+)(?:-(?P<max_port>\d+)?)?:(?P<source>[a-zA-Z0-9.\/]+)`)
+
 // ConvertFlagParamsToRules converts received input rules parameters into a Firewall Profile rules array
 func (fp *FirewallProfile) ConvertFlagParamsToRules(rulesIn string) error {
-	compRegEx := regexp.MustCompile(`(?P<ip_protocol>\w{3})\/(?P<min_port>\d+)(?:-(?P<max_port>\d+)?)?:(?P<source>[a-zA-Z0-9.\/]+)`)
 	for _, r := range strings.Split(rulesIn, ",") {
-		values := compRegEx.FindStringSubmatch(r)
+		values := firewallProfileRulesRegexp.FindStringSubmatch(r)
 		if len(values) == 0 {
 			return fmt.Errorf("invalid input rule format %s", r)
 		}
-		names := compRegEx.SubexpNames()
+		names := firewallProfileRulesRegexp.SubexpNames()
 		mapValueByName := make(map[string]string)
 		for j := range values {
 			if names[j] != "" {

--- a/api/types/servers.go
+++ b/api/types/servers.go
@@ -1,7 +1,5 @@
 package types
 
-import "encoding/json"
-
 type Server struct {
 	ID                string `json:"id" header:"ID"`
 	Name              string `json:"name" header:"NAME"`
@@ -18,11 +16,11 @@ type Server struct {
 }
 
 type ScriptChar struct {
-	ResourceType    string           `json:"resource_type" header:"RESOURCE_TYPE" show:"noshow,nolist"`
-	ID              string           `json:"id" header:"ID"`
-	Type            string           `json:"type" header:"TYPE"`
-	ParameterValues *json.RawMessage `json:"parameter_values" header:"PARAMETER_VALUES"`
-	TemplateID      string           `json:"template_id" header:"TEMPLATE_ID"`
-	ScriptID        string           `json:"script_id" header:"SCRIPT_ID"`
-	ExecutionOrder  int              `json:"execution_order" header:"EXECUTION_ORDER" show:"noshow,nolist"`
+	ResourceType    string                 `json:"resource_type" header:"RESOURCE_TYPE" show:"noshow,nolist"`
+	ID              string                 `json:"id" header:"ID"`
+	Type            string                 `json:"type" header:"TYPE"`
+	ParameterValues map[string]interface{} `json:"parameter_values" header:"PARAMETER_VALUES"`
+	TemplateID      string                 `json:"template_id" header:"TEMPLATE_ID"`
+	ScriptID        string                 `json:"script_id" header:"SCRIPT_ID"`
+	ExecutionOrder  int                    `json:"execution_order" header:"EXECUTION_ORDER" show:"noshow,nolist"`
 }

--- a/api/types/templates.go
+++ b/api/types/templates.go
@@ -44,7 +44,7 @@ type TemplateServer struct {
 type TemplateScriptCredentials interface{}
 
 // cookbookVersionsMap stores template cookbook versions map
-type cookbookVersionsMap map[string]cookbookVersionsFields
+type cookbookVersionsMap map[string]*cookbookVersionsFields
 
 // cookbookVersionsFields stores cookbook versions fields: version/version_id
 type cookbookVersionsFields struct {
@@ -53,19 +53,14 @@ type cookbookVersionsFields struct {
 	VersionComposite string `json:"omitempty" header:"VERSION_COMPOSITE" show:"nolist,noheader"`
 }
 
-// FillInCookbookVersion resolves adequate cookbook version from version_id
-func (cbf *Template) FillInCookbookVersion(VersionByVersionID map[string]string) {
-	for name, cb := range cbf.CookbookVersions {
-		t := new(cookbookVersionsFields)
-		if _, found := VersionByVersionID[cb.VersionId]; found {
-			cb.Version = VersionByVersionID[cb.VersionId]
-			t.Version = cb.Version
-			t.VersionId = cb.VersionId
-			t.VersionComposite = strings.Join([]string{name, cb.Version}, ":")
+// FillInCookbookVersionComposite resolves adequate cookbook version from version_id
+func (t *Template) FillInCookbookVersionComposite(customCookbookVersionsByVersionID map[string]string) {
+	for name, cv := range t.CookbookVersions {
+		if v, found := customCookbookVersionsByVersionID[cv.VersionId]; found {
+			cv.Version = v
+			cv.VersionComposite = strings.Join([]string{name, v}, ":")
 		} else {
-			t.Version = cb.Version
-			t.VersionComposite = strings.Join([]string{name, strings.Replace(cb.Version, " ", "", -1)}, "")
+			cv.VersionComposite = strings.Join([]string{name, strings.Replace(cv.Version, " ", "", -1)}, "")
 		}
-		cbf.CookbookVersions[name] = *t
 	}
 }

--- a/api/types/templates.go
+++ b/api/types/templates.go
@@ -1,5 +1,9 @@
 package types
 
+import (
+	"strings"
+)
+
 // Template stores blueprint templates
 type Template struct {
 	ID                      string                 `json:"id,omitempty" header:"ID"`
@@ -44,19 +48,24 @@ type cookbookVersionsMap map[string]cookbookVersionsFields
 
 // cookbookVersionsFields stores cookbook versions fields: version/version_id
 type cookbookVersionsFields struct {
-	Version   string `json:"version,omitempty" header:"VERSION"`
-	VersionId string `json:"version_id,omitempty" header:"VERSION_ID" show:"nolist,noshow"`
+	Version          string `json:"version,omitempty" header:"VERSION" show:"nolist,noshow"`
+	VersionId        string `json:"version_id,omitempty" header:"VERSION_ID" show:"nolist,noshow"`
+	VersionComposite string `json:"omitempty" header:"VERSION_COMPOSITE" show:"nolist,noheader"`
 }
 
 // FillInCookbookVersion resolves adequate cookbook version from version_id
 func (cbf *Template) FillInCookbookVersion(VersionByVersionID map[string]string) {
 	for name, cb := range cbf.CookbookVersions {
+		t := new(cookbookVersionsFields)
 		if _, found := VersionByVersionID[cb.VersionId]; found {
 			cb.Version = VersionByVersionID[cb.VersionId]
-			t := new(cookbookVersionsFields)
 			t.Version = cb.Version
 			t.VersionId = cb.VersionId
-			cbf.CookbookVersions[name] = *t
+			t.VersionComposite = strings.Join([]string{name, cb.Version}, ":")
+		} else {
+			t.Version = cb.Version
+			t.VersionComposite = strings.Join([]string{name, strings.Replace(cb.Version, " ", "", -1)}, "")
 		}
+		cbf.CookbookVersions[name] = *t
 	}
 }

--- a/api/types/templates.go
+++ b/api/types/templates.go
@@ -1,30 +1,26 @@
 package types
 
-import (
-	"encoding/json"
-)
-
 // Template stores blueprint templates
 type Template struct {
-	ID                      string           `json:"id,omitempty" header:"ID"`
-	Name                    string           `json:"name,omitempty" header:"NAME"`
-	GenericImageID          string           `json:"generic_image_id,omitempty" header:"GENERIC_IMAGE_ID"`
-	RunList                 []string         `json:"run_list,omitempty" header:"RUN_LIST" show:"nolist"`
-	ConfigurationAttributes *json.RawMessage `json:"configuration_attributes,omitempty" header:"CONFIGURATION_ATTRIBUTES" show:"nolist"`
-	ResourceType            string           `json:"resource_type" header:"RESOURCE_TYPE" show:"nolist"`
-	CookbookVersions        *json.RawMessage `json:"cookbook_versions,omitempty" header:"COOKBOOK_VERSIONS" show:"nolist"`
-	State                   string           `json:"state" header:"STATE" show:"nolist"`
+	ID                      string                 `json:"id,omitempty" header:"ID"`
+	Name                    string                 `json:"name,omitempty" header:"NAME"`
+	GenericImageID          string                 `json:"generic_image_id,omitempty" header:"GENERIC_IMAGE_ID"`
+	RunList                 []string               `json:"run_list,omitempty" header:"RUN_LIST" show:"nolist"`
+	ConfigurationAttributes map[string]interface{} `json:"configuration_attributes,omitempty" header:"CONFIGURATION_ATTRIBUTES" show:"nolist"`
+	ResourceType            string                 `json:"resource_type" header:"RESOURCE_TYPE" show:"nolist"`
+	CookbookVersions        map[string]interface{} `json:"cookbook_versions,omitempty" header:"COOKBOOK_VERSIONS" show:"nolist"`
+	State                   string                 `json:"state" header:"STATE" show:"nolist"`
 	LabelableFields
 }
 
 // TemplateScript stores a templates' script info
 type TemplateScript struct {
-	ID              string           `json:"id" header:"ID"`
-	Type            string           `json:"type" header:"TYPE"`
-	ExecutionOrder  int              `json:"execution_order" header:"EXECUTION_ORDER"`
-	TemplateID      string           `json:"template_id" header:"TEMPLATE_ID"`
-	ScriptID        string           `json:"script_id" header:"SCRIPT_ID"`
-	ParameterValues *json.RawMessage `json:"parameter_values" header:"PARAMETER_VALUES"`
+	ID              string                 `json:"id" header:"ID"`
+	Type            string                 `json:"type" header:"TYPE"`
+	ExecutionOrder  int                    `json:"execution_order" header:"EXECUTION_ORDER"`
+	TemplateID      string                 `json:"template_id" header:"TEMPLATE_ID"`
+	ScriptID        string                 `json:"script_id" header:"SCRIPT_ID"`
+	ParameterValues map[string]interface{} `json:"parameter_values" header:"PARAMETER_VALUES"`
 }
 
 // TemplateServer stores servers associated with the template

--- a/api/types/templates.go
+++ b/api/types/templates.go
@@ -8,7 +8,7 @@ type Template struct {
 	RunList                 []string               `json:"run_list,omitempty" header:"RUN_LIST" show:"nolist"`
 	ConfigurationAttributes map[string]interface{} `json:"configuration_attributes,omitempty" header:"CONFIGURATION_ATTRIBUTES" show:"nolist"`
 	ResourceType            string                 `json:"resource_type" header:"RESOURCE_TYPE" show:"nolist"`
-	CookbookVersions        map[string]interface{} `json:"cookbook_versions,omitempty" header:"COOKBOOK_VERSIONS" show:"nolist"`
+	CookbookVersions        cookbookVersionsMap    `json:"cookbook_versions,omitempty" header:"COOKBOOK_VERSIONS" show:"nolist"`
 	State                   string                 `json:"state" header:"STATE" show:"nolist"`
 	LabelableFields
 }
@@ -38,3 +38,25 @@ type TemplateServer struct {
 
 // TemplateScriptCredentials stores credentials to servers
 type TemplateScriptCredentials interface{}
+
+// cookbookVersionsMap stores template cookbook versions map
+type cookbookVersionsMap map[string]cookbookVersionsFields
+
+// cookbookVersionsFields stores cookbook versions fields: version/version_id
+type cookbookVersionsFields struct {
+	Version   string `json:"version,omitempty" header:"VERSION"`
+	VersionId string `json:"version_id,omitempty" header:"VERSION_ID" show:"nolist,noshow"`
+}
+
+// FillInCookbookVersion resolves adequate cookbook version from version_id
+func (cbf *Template) FillInCookbookVersion(VersionByVersionID map[string]string) {
+	for name, cb := range cbf.CookbookVersions {
+		if _, found := VersionByVersionID[cb.VersionId]; found {
+			cb.Version = VersionByVersionID[cb.VersionId]
+			t := new(cookbookVersionsFields)
+			t.Version = cb.Version
+			t.VersionId = cb.VersionId
+			cbf.CookbookVersions[name] = *t
+		}
+	}
+}

--- a/blueprint/templates/subcommands.go
+++ b/blueprint/templates/subcommands.go
@@ -45,15 +45,19 @@ func SubCommands() []cli.Command {
 				},
 				cli.StringFlag{
 					Name:  "run-list",
-					Usage: "A list of comma separated cookbook recipes that is run on the servers at start-up",
+					Usage: "A list of comma separated cookbook recipes that is run on the servers at start-up, i.e: --run-list wordpress,nano,1password",
 				},
 				cli.StringFlag{
 					Name:  "cookbook-versions",
-					Usage: "The cookbook versions used to configure the service recipes in the run-list",
+					Usage: "The cookbook versions used to configure the service recipes in the run-list, i.e: --cookbook-versions \"wordpress:0.1.0,nano=2.0.1,1password~>1.3.0\" \n\tCookbook version format: [NAME<OPERATOR>VERSION] \n\tSupported Operators:\n\t\tChef supermarket cookbook '~>','=','>=','>','<','<='\n\t\tUploaded cookbook ':'",
 				},
 				cli.StringFlag{
 					Name:  "configuration-attributes",
-					Usage: "The attributes used to configure the service recipes in the run-list",
+					Usage: "The attributes used to configure the service recipes in the run-list, as a json formatted parameter",
+				},
+				cli.StringFlag{
+					Name:  "configuration-attributes-from-file",
+					Usage: "The attributes used to configure the service recipes in the run-list, from file or STDIN, as a json formatted parameter. \n\tFrom file: --configuration-attributes-from-file attrs.json \n\tFrom STDIN: --configuration-attributes-from-file -",
 				},
 				cli.StringFlag{
 					Name:  "labels",
@@ -76,15 +80,19 @@ func SubCommands() []cli.Command {
 				},
 				cli.StringFlag{
 					Name:  "run-list",
-					Usage: "A list of comma separated cookbook recipes that is run on the servers at start-up",
+					Usage: "A list of comma separated cookbook recipes that is run on the servers at start-up, i.e: --run-list wordpress,nano,1password",
 				},
 				cli.StringFlag{
 					Name:  "cookbook-versions",
-					Usage: "The cookbook versions used to configure the service recipes in the run-list",
+					Usage: "The cookbook versions used to configure the service recipes in the run-list, i.e: --cookbook-versions \"wordpress:0.1.0,nano=2.0.1,1password~>1.3.0\" \n\tCookbook version format: [NAME<OPERATOR>VERSION] \n\tSupported Operators:\n\t\tChef supermarket cookbook '~>','=','>=','>','<','<='\n\t\tUploaded cookbook ':'",
 				},
 				cli.StringFlag{
 					Name:  "configuration-attributes",
-					Usage: "The attributes used to configure the service recipes in the run-list",
+					Usage: "The attributes used to configure the service recipes in the run-list, as a json formatted parameter",
+				},
+				cli.StringFlag{
+					Name:  "configuration-attributes-from-file",
+					Usage: "The attributes used to configure the service recipes in the run-list, from file or STDIN, as a json formatted parameter. \n\tFrom file: --configuration-attributes-from-file attrs.json \n\tFrom STDIN: --configuration-attributes-from-file -",
 				},
 			},
 		},
@@ -159,7 +167,7 @@ func SubCommands() []cli.Command {
 				},
 				cli.StringFlag{
 					Name:  "parameter-values",
-					Usage: "A map that assigns a value to each script parameter. Example: '{\"param1\":\"val1\",\"param2\":\"val2\"}'",
+					Usage: "A list of comma separated script parameters paired by Id and Value, i.e: --parameter-values param1:val1,param2:val2",
 				},
 			},
 		},
@@ -182,7 +190,7 @@ func SubCommands() []cli.Command {
 				},
 				cli.StringFlag{
 					Name:  "parameter-values",
-					Usage: "A map that assigns a value to each script parameter. Example: '{\"param1\":\"val1\",\"param2\":\"val2\"}'",
+					Usage: "A list of comma separated script parameters paired by Id and Value, i.e: --parameter-values param1:val1,param2:val2",
 				},
 			},
 		},
@@ -201,7 +209,7 @@ func SubCommands() []cli.Command {
 				},
 				cli.StringFlag{
 					Name:  "script-ids",
-					Usage: "An array that must contain all the ids of scripts of the given template and type in the desired execution order",
+					Usage: "A list of comma separated scripts ids that must contain all the ids of scripts of the given template and type in the desired execution order",
 				},
 			},
 		},

--- a/blueprint/templates/subcommands.go
+++ b/blueprint/templates/subcommands.go
@@ -45,15 +45,15 @@ func SubCommands() []cli.Command {
 				},
 				cli.StringFlag{
 					Name:  "run-list",
-					Usage: "A list of comma separated cookbook recipes that is run on the servers at start-up, i.e: --run-list imco::client,1password,wordpress",
+					Usage: "A list of comma separated cookbook recipes that is run on the servers at start-up, i.e: --run-list imco::client,1password,joomla",
 				},
 				cli.StringFlag{
 					Name:  "cookbook-versions",
-					Usage: "The cookbook versions used to configure the service recipes in the run-list, i.e: --cookbook-versions \"imco:3.0.3,1password~>1.3.0,wordpress:0.1.0\" \n\tCookbook version format: [NAME<OPERATOR>VERSION] \n\tSupported Operators:\n\t\tChef supermarket cookbook '~>','=','>=','>','<','<='\n\t\tUploaded cookbook ':'",
+					Usage: "The cookbook versions used to configure the service recipes in the run-list, i.e: --cookbook-versions \"imco:3.0.3,1password~>1.3.0,joomla:0.11.0\" \n\tCookbook version format: [NAME<OPERATOR>VERSION] \n\tSupported Operators:\n\t\tChef supermarket cookbook '~>','=','>=','>','<','<='\n\t\tUploaded cookbook ':'",
 				},
 				cli.StringFlag{
 					Name:  "configuration-attributes",
-					Usage: "The attributes used to configure the service recipes in the run-list, as a json formatted parameter",
+					Usage: "The attributes used to configure the service recipes in the run-list, as a json formatted parameter. i.e: --configuration-attributes '{\"joomla\":{\"db\":{\"password\":\"my_pass\"},\"port\":\"8080\"}}'",
 				},
 				cli.StringFlag{
 					Name:  "configuration-attributes-from-file",
@@ -80,15 +80,15 @@ func SubCommands() []cli.Command {
 				},
 				cli.StringFlag{
 					Name:  "run-list",
-					Usage: "A list of comma separated cookbook recipes that is run on the servers at start-up, i.e: --run-list imco::client,1password,wordpress",
+					Usage: "A list of comma separated cookbook recipes that is run on the servers at start-up, i.e: --run-list imco::client,1password,joomla",
 				},
 				cli.StringFlag{
 					Name:  "cookbook-versions",
-					Usage: "The cookbook versions used to configure the service recipes in the run-list, i.e: --cookbook-versions \"imco:3.0.3,1password~>1.3.0,wordpress:0.1.0\" \n\tCookbook version format: [NAME<OPERATOR>VERSION] \n\tSupported Operators:\n\t\tChef supermarket cookbook '~>','=','>=','>','<','<='\n\t\tUploaded cookbook ':'",
+					Usage: "The cookbook versions used to configure the service recipes in the run-list, i.e: --cookbook-versions \"imco:3.0.3,1password~>1.3.0,joomla:0.11.0\" \n\tCookbook version format: [NAME<OPERATOR>VERSION] \n\tSupported Operators:\n\t\tChef supermarket cookbook '~>','=','>=','>','<','<='\n\t\tUploaded cookbook ':'",
 				},
 				cli.StringFlag{
 					Name:  "configuration-attributes",
-					Usage: "The attributes used to configure the service recipes in the run-list, as a json formatted parameter",
+					Usage: "The attributes used to configure the service recipes in the run-list, as a json formatted parameter. i.e: --configuration-attributes '{\"joomla\":{\"db\":{\"password\":\"my_pass\"},\"port\":\"8080\"}}'",
 				},
 				cli.StringFlag{
 					Name:  "configuration-attributes-from-file",

--- a/blueprint/templates/subcommands.go
+++ b/blueprint/templates/subcommands.go
@@ -45,11 +45,11 @@ func SubCommands() []cli.Command {
 				},
 				cli.StringFlag{
 					Name:  "run-list",
-					Usage: "A list of comma separated cookbook recipes that is run on the servers at start-up, i.e: --run-list wordpress,nano,1password",
+					Usage: "A list of comma separated cookbook recipes that is run on the servers at start-up, i.e: --run-list imco::client,1password,wordpress",
 				},
 				cli.StringFlag{
 					Name:  "cookbook-versions",
-					Usage: "The cookbook versions used to configure the service recipes in the run-list, i.e: --cookbook-versions \"wordpress:0.1.0,nano=2.0.1,1password~>1.3.0\" \n\tCookbook version format: [NAME<OPERATOR>VERSION] \n\tSupported Operators:\n\t\tChef supermarket cookbook '~>','=','>=','>','<','<='\n\t\tUploaded cookbook ':'",
+					Usage: "The cookbook versions used to configure the service recipes in the run-list, i.e: --cookbook-versions \"imco:3.0.3,1password~>1.3.0,wordpress:0.1.0\" \n\tCookbook version format: [NAME<OPERATOR>VERSION] \n\tSupported Operators:\n\t\tChef supermarket cookbook '~>','=','>=','>','<','<='\n\t\tUploaded cookbook ':'",
 				},
 				cli.StringFlag{
 					Name:  "configuration-attributes",
@@ -80,11 +80,11 @@ func SubCommands() []cli.Command {
 				},
 				cli.StringFlag{
 					Name:  "run-list",
-					Usage: "A list of comma separated cookbook recipes that is run on the servers at start-up, i.e: --run-list wordpress,nano,1password",
+					Usage: "A list of comma separated cookbook recipes that is run on the servers at start-up, i.e: --run-list imco::client,1password,wordpress",
 				},
 				cli.StringFlag{
 					Name:  "cookbook-versions",
-					Usage: "The cookbook versions used to configure the service recipes in the run-list, i.e: --cookbook-versions \"wordpress:0.1.0,nano=2.0.1,1password~>1.3.0\" \n\tCookbook version format: [NAME<OPERATOR>VERSION] \n\tSupported Operators:\n\t\tChef supermarket cookbook '~>','=','>=','>','<','<='\n\t\tUploaded cookbook ':'",
+					Usage: "The cookbook versions used to configure the service recipes in the run-list, i.e: --cookbook-versions \"imco:3.0.3,1password~>1.3.0,wordpress:0.1.0\" \n\tCookbook version format: [NAME<OPERATOR>VERSION] \n\tSupported Operators:\n\t\tChef supermarket cookbook '~>','=','>=','>','<','<='\n\t\tUploaded cookbook ':'",
 				},
 				cli.StringFlag{
 					Name:  "configuration-attributes",

--- a/blueprint/templates/subcommands.go
+++ b/blueprint/templates/subcommands.go
@@ -167,7 +167,11 @@ func SubCommands() []cli.Command {
 				},
 				cli.StringFlag{
 					Name:  "parameter-values",
-					Usage: "A list of comma separated script parameters paired by Id and Value, i.e: --parameter-values param1:val1,param2:val2",
+					Usage: "A map that assigns a value to each script parameter, as a json formatted parameter; i.e: '{\"param1\":\"val1\",\"param2\":\"val2\"}'",
+				},
+				cli.StringFlag{
+					Name:  "parameter-values-from-file",
+					Usage: "A map that assigns a value to each script parameter, from file or STDIN, as a json formatted parameter. \n\tFrom file: --parameter-values-from-file params.json \n\tFrom STDIN: --parameter-values-from-file -",
 				},
 			},
 		},
@@ -186,7 +190,11 @@ func SubCommands() []cli.Command {
 				},
 				cli.StringFlag{
 					Name:  "parameter-values",
-					Usage: "A list of comma separated script parameters paired by Id and Value, i.e: --parameter-values param1:val1,param2:val2",
+					Usage: "A map that assigns a value to each script parameter, as a json formatted parameter; i.e: '{\"param1\":\"val1\",\"param2\":\"val2\"}'",
+				},
+				cli.StringFlag{
+					Name:  "parameter-values-from-file",
+					Usage: "A map that assigns a value to each script parameter, from file or STDIN, as a json formatted parameter. \n\tFrom file: --parameter-values-from-file params.json \n\tFrom STDIN: --parameter-values-from-file -",
 				},
 			},
 		},

--- a/blueprint/templates/subcommands.go
+++ b/blueprint/templates/subcommands.go
@@ -181,10 +181,6 @@ func SubCommands() []cli.Command {
 					Usage: "Template Id",
 				},
 				cli.StringFlag{
-					Name:  "script-id",
-					Usage: "Identifier for the script that is parameterised by the script characterisation",
-				},
-				cli.StringFlag{
 					Name:  "id",
 					Usage: "Identifier for the template-script that is parameterised by the script characterisation",
 				},

--- a/bootstrapping/bootstrapping.go
+++ b/bootstrapping/bootstrapping.go
@@ -45,7 +45,7 @@ type bootstrappingProcess struct {
 }
 type attributes struct {
 	revisionID string
-	rawData    *json.RawMessage
+	rawData    map[string]interface{}
 }
 
 type policyfile types.BootstrappingPolicyfile

--- a/cmd/firewall_profiles_cmd.go
+++ b/cmd/firewall_profiles_cmd.go
@@ -128,10 +128,10 @@ func FirewallProfileUpdate(c *cli.Context) error {
 	checkRequiredFlags(c, []string{"id"}, formatter)
 
 	firewallProfileIn := map[string]interface{}{}
-	if c.String("rules") != "" {
+	if c.String("name") != "" {
 		firewallProfileIn["name"] = c.String("name")
 	}
-	if c.String("rules") != "" {
+	if c.String("description") != "" {
 		firewallProfileIn["description"] = c.String("description")
 	}
 	if c.String("rules") != "" {

--- a/cmd/firewall_profiles_cmd.go
+++ b/cmd/firewall_profiles_cmd.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-
 	"github.com/codegangsta/cli"
 	"github.com/ingrammicro/concerto/api/network"
 	"github.com/ingrammicro/concerto/api/types"
@@ -88,17 +87,18 @@ func FirewallProfileCreate(c *cli.Context) error {
 	firewallProfileSvc, formatter := WireUpFirewallProfile(c)
 
 	checkRequiredFlags(c, []string{"name", "description"}, formatter)
-	params, err := utils.FlagConvertParamsJSON(c, []string{"rules"})
-	if err != nil {
-		formatter.PrintFatal("Error parsing parameters", err)
-	}
 
 	firewallProfileIn := map[string]interface{}{
 		"name":        c.String("name"),
 		"description": c.String("description"),
 	}
+
 	if c.String("rules") != "" {
-		firewallProfileIn["rules"] = (*params)["rules"]
+		fw := new(types.FirewallProfile)
+		if err := fw.ConvertFlagParamsToRules(c.String("rules")); err != nil {
+			formatter.PrintFatal("Error parsing parameters", err)
+		}
+		firewallProfileIn["rules"] = fw.Rules
 	}
 
 	labelIDsByName, labelNamesByID := LabelLoadsMapping(c)
@@ -126,11 +126,23 @@ func FirewallProfileUpdate(c *cli.Context) error {
 	firewallProfileSvc, formatter := WireUpFirewallProfile(c)
 
 	checkRequiredFlags(c, []string{"id"}, formatter)
-	params, err := utils.FlagConvertParamsJSON(c, []string{"rules"})
-	if err != nil {
-		formatter.PrintFatal("Error parsing parameters", err)
+
+	firewallProfileIn := map[string]interface{}{}
+	if c.String("rules") != "" {
+		firewallProfileIn["name"] = c.String("name")
 	}
-	firewallProfile, err := firewallProfileSvc.UpdateFirewallProfile(params, c.String("id"))
+	if c.String("rules") != "" {
+		firewallProfileIn["description"] = c.String("description")
+	}
+	if c.String("rules") != "" {
+		fw := new(types.FirewallProfile)
+		if err := fw.ConvertFlagParamsToRules(c.String("rules")); err != nil {
+			formatter.PrintFatal("Error parsing parameters", err)
+		}
+		firewallProfileIn["rules"] = fw.Rules
+	}
+
+	firewallProfile, err := firewallProfileSvc.UpdateFirewallProfile(&firewallProfileIn, c.String("id"))
 	if err != nil {
 		formatter.PrintFatal("Couldn't update firewallProfile", err)
 	}

--- a/cmd/template_cmd.go
+++ b/cmd/template_cmd.go
@@ -411,7 +411,7 @@ func convertFlagParamsToCookbookVersions(c *cli.Context, cbvsIn string) (map[str
 			}
 			// provided cookbook version does not match the available uploaded
 			if _, found := result[name]; !found {
-				return nil, fmt.Errorf("invalid cookbook version: %s does not match the available uploaded", cbvIn)
+				return nil, fmt.Errorf("invalid cookbook version: %s does not match any of the cookbook versions uploaded to the platform", cbvIn)
 			}
 		} else {
 			//supermarket
@@ -470,7 +470,7 @@ func convertFlagParamsToConfigurationAttributesFromFile(c *cli.Context, casIn st
 
 		attrsFile, err := os.Open(sourceFilePath)
 		if err != nil {
-			return nil, fmt.Errorf("cannot open file: %s. %v", sourceFilePath, err)
+			return nil, fmt.Errorf("cannot open file %s: %v", sourceFilePath, err)
 		}
 		defer attrsFile.Close()
 

--- a/cmd/template_cmd.go
+++ b/cmd/template_cmd.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"bufio"
 	"encoding/json"
 	"fmt"
-	"github.com/Sirupsen/logrus"
+	log "github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
 	"github.com/ingrammicro/concerto/api/blueprint"
 	"github.com/ingrammicro/concerto/api/types"
@@ -443,22 +442,8 @@ func convertFlagParamsToConfigurationAttributesFromFile(c *cli.Context, casIn st
 	var content map[string]interface{}
 	if casIn == "-" {
 		// read from STDIN
-		logrus.Info("Please, write configuration parameters json formatted:")
-		buff := ""
-		scanner := bufio.NewScanner(os.Stdin)
-		for scanner.Scan() {
-			line := scanner.Text()
-			if len(line) == 0 {
-				logrus.Info("Processing...")
-				break
-			}
-			buff += line
-		}
-		if err := scanner.Err(); err != nil {
-			return nil, fmt.Errorf("cannot read from standard input: %v", err)
-		}
-
-		if err := json.NewDecoder(strings.NewReader(buff)).Decode(&content); err != nil {
+		log.Info("Please, write configuration parameters json formatted:")
+		if err := json.NewDecoder(os.Stdin).Decode(&content); err != nil {
 			return nil, fmt.Errorf("invalid json formatted attributes")
 		}
 	} else {

--- a/cmd/template_cmd.go
+++ b/cmd/template_cmd.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 )
 
-var templateCookbookVersionValueRegexp = regexp.MustCompile(`^(.*?)(~>|=|>=|<=|>|<|:)(\d+(?:\.\d+)+)$`)
+var templateCookbookVersionValueRegexp = regexp.MustCompile(`^(.+?)(~>|=|>=|<=|>|<|:)(\d+(?:\.\d+){0,2})$`)
 
 // WireUpTemplate prepares common resources to send request to Concerto API
 func WireUpTemplate(c *cli.Context) (ts *blueprint.TemplateService, f format.Formatter) {

--- a/cmd/template_cmd.go
+++ b/cmd/template_cmd.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 )
 
-var templateCookbookVersionValueRegexp = regexp.MustCompile(`^(.+?)(~>|=|>=|<=|>|<|:)(\d+(?:\.\d+){0,2})$`)
+var templateCookbookVersionValueRegexp = regexp.MustCompile(`^([a-zA-Z0-9_-]+)(~>|=|>=|<=|>|<|:)(\d+(?:\.\d+){0,2})$`)
 
 // WireUpTemplate prepares common resources to send request to Concerto API
 func WireUpTemplate(c *cli.Context) (ts *blueprint.TemplateService, f format.Formatter) {

--- a/cmd/template_cmd.go
+++ b/cmd/template_cmd.go
@@ -82,7 +82,7 @@ func TemplateShow(c *cli.Context) error {
 		formatter.PrintFatal("Couldn't receive template data", err)
 	}
 
-	if err = resolveCookbookVersion(c, template); err != nil {
+	if err = resolveCookbookVersions(c, template); err != nil {
 		formatter.PrintFatal("cannot resolve cookbook versions data", err)
 	}
 
@@ -146,7 +146,7 @@ func TemplateCreate(c *cli.Context) error {
 		formatter.PrintFatal("Couldn't create template", err)
 	}
 
-	if err = resolveCookbookVersion(c, template); err != nil {
+	if err = resolveCookbookVersions(c, template); err != nil {
 		formatter.PrintFatal("cannot resolve cookbook versions data", err)
 	}
 
@@ -202,7 +202,7 @@ func TemplateUpdate(c *cli.Context) error {
 		formatter.PrintFatal("Couldn't update template", err)
 	}
 
-	if err = resolveCookbookVersion(c, template); err != nil {
+	if err = resolveCookbookVersions(c, template); err != nil {
 		formatter.PrintFatal("cannot resolve cookbook versions data", err)
 	}
 
@@ -225,7 +225,7 @@ func TemplateCompile(c *cli.Context) error {
 		formatter.PrintFatal("Couldn't compile template", err)
 	}
 
-	if err = resolveCookbookVersion(c, template); err != nil {
+	if err = resolveCookbookVersions(c, template); err != nil {
 		formatter.PrintFatal("cannot resolve cookbook versions data", err)
 	}
 
@@ -480,19 +480,19 @@ func convertFlagParamsJsonFromFileOrStdin(c *cli.Context, dataIn string) (map[st
 	return content, nil
 }
 
-// resolveCookbookVersion resolves adequate cookbook version ids
-func resolveCookbookVersion(c *cli.Context, template *types.Template) error {
+// resolveCookbookVersions resolves adequate cookbook version ids
+func resolveCookbookVersions(c *cli.Context, template *types.Template) error {
 	svc, _ := WireUpCookbookVersion(c)
 	cbvs, err := svc.GetCookbookVersionList()
 	if err != nil {
 		return err
 	}
 
-	VersionByVersionID := make(map[string]string)
+	customCookbookVersionsByVersionID := make(map[string]string)
 	for _, cbv := range cbvs {
-		VersionByVersionID[cbv.ID] = cbv.Version
+		customCookbookVersionsByVersionID[cbv.ID] = cbv.Version
 	}
-	template.FillInCookbookVersion(VersionByVersionID)
+	template.FillInCookbookVersionComposite(customCookbookVersionsByVersionID)
 
 	return nil
 }

--- a/firewall/discovery/windows.go
+++ b/firewall/discovery/windows.go
@@ -27,7 +27,7 @@ func CurrentFirewallRules() ([]*FirewallChain, error) {
 	if err != nil {
 		return nil, err
 	}
-	fmt.Printf("DEBUG: discovered following enabled profiles\n", profiles)
+	fmt.Printf("DEBUG: discovered following enabled profiles %v\n", profiles)
 	cmd := exec.Command("netsh", "advfirewall", "firewall", "show", "rule", "name=all", "dir=in")
 	out := &bytes.Buffer{}
 	cmd.Stdout = out

--- a/firewall/iptables.go
+++ b/firewall/iptables.go
@@ -37,7 +37,7 @@ func Apply(policy types.Policy) error {
 
 	_, exitCode, _, _ = utils.RunCmd("/sbin/iptables -w -C INPUT -j CONCERTO")
 	if exitCode != 0 {
-		log.Debugln("Concerto Chain is not existant adding it to INPUT")
+		log.Debugln("Concerto Chain is not existent adding it to INPUT")
 		utils.RunCmd("/sbin/iptables -w -A INPUT -j CONCERTO")
 	}
 

--- a/main.go
+++ b/main.go
@@ -2,26 +2,25 @@ package main
 
 import (
 	"fmt"
+	log "github.com/Sirupsen/logrus"
+	"github.com/codegangsta/cli"
+	"github.com/ingrammicro/concerto/audit"
 	"github.com/ingrammicro/concerto/blueprint"
 	"github.com/ingrammicro/concerto/bootstrapping"
 	"github.com/ingrammicro/concerto/brownfield"
 	"github.com/ingrammicro/concerto/cloud"
 	"github.com/ingrammicro/concerto/cmdpolling"
 	"github.com/ingrammicro/concerto/converge"
+	"github.com/ingrammicro/concerto/dispatcher"
+	"github.com/ingrammicro/concerto/firewall"
 	"github.com/ingrammicro/concerto/labels"
 	"github.com/ingrammicro/concerto/network"
 	"github.com/ingrammicro/concerto/settings"
+	"github.com/ingrammicro/concerto/utils"
+	"github.com/ingrammicro/concerto/utils/format"
 	"github.com/ingrammicro/concerto/wizard"
 	"os"
 	"sort"
-
-	log "github.com/Sirupsen/logrus"
-	"github.com/codegangsta/cli"
-	"github.com/ingrammicro/concerto/audit"
-	"github.com/ingrammicro/concerto/dispatcher"
-	"github.com/ingrammicro/concerto/firewall"
-	"github.com/ingrammicro/concerto/utils"
-	"github.com/ingrammicro/concerto/utils/format"
 )
 
 var serverCommands = []cli.Command{

--- a/network/firewall_profiles/subcommands.go
+++ b/network/firewall_profiles/subcommands.go
@@ -45,7 +45,7 @@ func SubCommands() []cli.Command {
 				},
 				cli.StringFlag{
 					Name:  "rules",
-					Usage: "Set of rules of the firewall profile",
+					Usage: "Set of rules of the firewall profile, i.e: --rules TCP/8080-8081:0.0.0.0/0,TCP/9090-9091:any,UDP/3456:1.2.3.4\n\tRule format: [PROTOCOL/MIN_PORT[-MAX_PORT]:CIDR_IP]",
 				},
 				cli.StringFlag{
 					Name:  "labels",
@@ -72,7 +72,7 @@ func SubCommands() []cli.Command {
 				},
 				cli.StringFlag{
 					Name:  "rules",
-					Usage: "Set of rules of the firewall profile",
+					Usage: "Set of rules of the firewall profile, i.e: --rules TCP/8080-8081:0.0.0.0/0,TCP/9090-9091:any,UDP/3456:1.2.3.4\n\tRule format: [PROTOCOL/MIN_PORT[-MAX_PORT]:CIDR_IP]",
 				},
 			},
 		},

--- a/testdata/apps_data.go
+++ b/testdata/apps_data.go
@@ -1,28 +1,22 @@
 package testdata
 
 import (
-	"encoding/json"
-
 	"github.com/ingrammicro/concerto/api/types"
 )
 
 // GetAppData loads test data
 func GetAppData() []*types.WizardApp {
-
-	param0 := json.RawMessage(`{"fakeFlavour01":"x","fakeFlavour02":"y"}`)
-	param1 := json.RawMessage(`{"fakeFlavour11":"a","fakeFlavour12":"b"}`)
-
 	return []*types.WizardApp{
 		{
 			ID:                  "fakeID0",
 			Name:                "fakeName0",
-			FlavourRequirements: param0,
+			FlavourRequirements: map[string]interface{}{"fakeFlavour01": "x", "fakeFlavour02": "y"},
 			GenericImageID:      "fakeGenericImageID0",
 		},
 		{
 			ID:                  "fakeID1",
 			Name:                "fakeName1",
-			FlavourRequirements: param1,
+			FlavourRequirements: map[string]interface{}{"fakeFlavour11": "a", "fakeFlavour12": "b"},
 			GenericImageID:      "fakeGenericImageID1",
 		},
 	}

--- a/testdata/boostrapping_data.go
+++ b/testdata/boostrapping_data.go
@@ -1,14 +1,12 @@
 package testdata
 
 import (
-	"encoding/json"
 	"github.com/ingrammicro/concerto/api/types"
 )
 
 // GetBootstrappingConfigurationData loads test data
 func GetBootstrappingConfigurationData() *types.BootstrappingConfiguration {
 
-	attrs := json.RawMessage(`{"fakeAttribute0":"val0","fakeAttribute1":"val1"}`)
 	return &types.BootstrappingConfiguration{
 		Policyfiles: []types.BootstrappingPolicyfile{
 			{
@@ -22,7 +20,7 @@ func GetBootstrappingConfigurationData() *types.BootstrappingConfiguration {
 				DownloadURL: "fakeProfileDownloadURL1",
 			},
 		},
-		Attributes:          &attrs,
+		Attributes:          map[string]interface{}{"fakeAttribute0": "val0", "fakeAttribute1": "val1"},
 		AttributeRevisionID: "fakeAttributeRevisionID",
 	}
 }

--- a/testdata/dummy_data.go
+++ b/testdata/dummy_data.go
@@ -1,35 +1,30 @@
 package testdata
 
-import (
-	"encoding/json"
-)
+import "time"
 
 // DummyStructTestFormatter resolves type for testing
 type DummyStructTestFormatter struct {
-	ID               string           `json:"id" header:"ID"`
-	RemainingSeconds float32          `json:"remaining_seconds" header:"REMAINING SECONDS" show:"minifySeconds"`
-	JSONRaw          json.RawMessage  `json:"json_raw" header:"JSON RAW"`
-	JSONRawPtr       *json.RawMessage `json:"json_raw_ptr" header:"JSON RAW PTR"`
+	ID               string                 `json:"id" header:"ID"`
+	RemainingSeconds float32                `json:"remaining_seconds" header:"REMAINING SECONDS" show:"minifySeconds"`
+	JSONRaw          map[string]interface{} `json:"json_raw" header:"JSON RAW"`
+	Time             time.Time              `json:"time" header:"TIME"`
 }
 
 // GetDummyData loads test data
 func GetDummyData() []*DummyStructTestFormatter {
 
-	param0 := json.RawMessage(`{"fakeFlavour01":"x","fakeFlavour02":"y"}`)
-	param1 := json.RawMessage(`{"fakeFlavour11":"a","fakeFlavour12":"b"}`)
-
 	return []*DummyStructTestFormatter{
 		{
 			ID:               "fakeID0",
 			RemainingSeconds: 100360012,
-			JSONRaw:          param0,
-			JSONRawPtr:       &param1,
+			JSONRaw:          map[string]interface{}{"fakeFlavour01": "x", "fakeFlavour02": "y"},
+			Time:             time.Now(),
 		},
 		{
 			ID:               "fakeID1",
 			RemainingSeconds: 1,
-			JSONRaw:          param0,
-			JSONRawPtr:       nil,
+			JSONRaw:          map[string]interface{}{"fakeFlavour11": "a", "fakeFlavour12": "b"},
+			Time:             time.Now(),
 		},
 	}
 }

--- a/testdata/servers_data.go
+++ b/testdata/servers_data.go
@@ -1,7 +1,6 @@
 package testdata
 
 import (
-	"encoding/json"
 	"github.com/ingrammicro/concerto/api/types"
 )
 
@@ -37,14 +36,11 @@ func GetServerData() []*types.Server {
 // GetScriptCharData loads test data
 func GetScriptCharData() []*types.ScriptChar {
 
-	param0 := json.RawMessage(`{"fakeConf01":"x","fakeConf02":"y"}`)
-	param1 := json.RawMessage(`{"fakeConf11":"x","fakeConf12":"y"}`)
-
 	return []*types.ScriptChar{
 		{
 			ID:              "fakeID0",
 			Type:            "fakeType0",
-			ParameterValues: &param0,
+			ParameterValues: map[string]interface{}{"fakeConf01": "x", "fakeConf02": "y"},
 			TemplateID:      "fakeTemplateID0",
 			ScriptID:        "fakeScriptID0",
 			ExecutionOrder:  0,
@@ -53,7 +49,7 @@ func GetScriptCharData() []*types.ScriptChar {
 		{
 			ID:              "fakeID1",
 			Type:            "fakeType1",
-			ParameterValues: &param1,
+			ParameterValues: map[string]interface{}{"fakeConf11": "x", "fakeConf12": "y"},
 			TemplateID:      "fakeTemplateID1",
 			ScriptID:        "fakeScriptID1",
 			ExecutionOrder:  1,

--- a/testdata/template_data.go
+++ b/testdata/template_data.go
@@ -1,15 +1,11 @@
 package testdata
 
 import (
-	"encoding/json"
-
 	"github.com/ingrammicro/concerto/api/types"
 )
 
 // GetTemplateData loads loads test data
 func GetTemplateData() []*types.Template {
-	conf0 := json.RawMessage(`{"fakeConf01":"x","fakeConf02":"y"}`)
-	conf1 := json.RawMessage(`{"fakeConf11":"x","fakeConf12":"y"}`)
 
 	return []*types.Template{
 		{
@@ -17,14 +13,14 @@ func GetTemplateData() []*types.Template {
 			Name:                    "fakeName0",
 			GenericImageID:          "fakeGenericImageID0",
 			RunList:                 []string{"fakeRunList01", "fakeRunList02"},
-			ConfigurationAttributes: &conf0,
+			ConfigurationAttributes: map[string]interface{}{"fakeConf01": "x", "fakeConf02": "y"},
 		},
 		{
 			ID:                      "fakeID1",
 			Name:                    "fakeName1",
 			GenericImageID:          "fakeGenericImageID1",
 			RunList:                 []string{"fakeRunList11", "fakeRunList12", "fakeRunList13"},
-			ConfigurationAttributes: &conf1,
+			ConfigurationAttributes: map[string]interface{}{"fakeConf11": "x", "fakeConf12": "y"},
 		},
 		{
 			ID:                      "fakeID2",
@@ -39,11 +35,6 @@ func GetTemplateData() []*types.Template {
 // GetTemplateScriptData loads test data
 func GetTemplateScriptData() []*types.TemplateScript {
 
-	param0 := json.RawMessage(`{"fakeConf01":"x","fakeConf02":"y"}`)
-	param1 := json.RawMessage(`{"fakeConf11":"x","fakeConf12":"y"}`)
-	param2 := json.RawMessage(`{"fakeConf21":"x","fakeConf22":"y"}`)
-	param3 := json.RawMessage(`{"fakeConf31":"x","fakeConf32":"y"}`)
-
 	return []*types.TemplateScript{
 		{
 			ID:              "fakeID0",
@@ -51,7 +42,7 @@ func GetTemplateScriptData() []*types.TemplateScript {
 			ExecutionOrder:  1,
 			TemplateID:      "fakeTemplateID0",
 			ScriptID:        "fakeScriptID0",
-			ParameterValues: &param0,
+			ParameterValues: map[string]interface{}{"fakeConf01": "x", "fakeConf02": "y"},
 		},
 		{
 			ID:              "fakeID1",
@@ -59,7 +50,7 @@ func GetTemplateScriptData() []*types.TemplateScript {
 			ExecutionOrder:  4,
 			TemplateID:      "fakeTemplateID1",
 			ScriptID:        "fakeScriptID1",
-			ParameterValues: &param1,
+			ParameterValues: map[string]interface{}{"fakeConf11": "x", "fakeConf12": "y"},
 		},
 		{
 			ID:              "fakeID2",
@@ -67,7 +58,7 @@ func GetTemplateScriptData() []*types.TemplateScript {
 			ExecutionOrder:  2,
 			TemplateID:      "fakeTemplateID2",
 			ScriptID:        "fakeScriptID2",
-			ParameterValues: &param2,
+			ParameterValues: map[string]interface{}{"fakeConf21": "x", "fakeConf22": "y"},
 		},
 		{
 			ID:              "fakeID3",
@@ -75,7 +66,7 @@ func GetTemplateScriptData() []*types.TemplateScript {
 			ExecutionOrder:  3,
 			TemplateID:      "fakeTemplateID3",
 			ScriptID:        "fakeScriptID3",
-			ParameterValues: &param3,
+			ParameterValues: map[string]interface{}{"fakeConf31": "x", "fakeConf32": "y"},
 		},
 	}
 }

--- a/utils/cli_parameters.go
+++ b/utils/cli_parameters.go
@@ -68,10 +68,3 @@ func ItemConvertParams(item interface{}) (*map[string]interface{}, error) {
 	}
 	return &v, nil
 }
-
-// JSONParam parses parameter as json structure
-func JSONParam(param string) (interface{}, error) {
-	var p interface{}
-	err := json.Unmarshal([]byte(param), &p)
-	return p, err
-}

--- a/utils/config.go
+++ b/utils/config.go
@@ -391,7 +391,7 @@ func (config *Config) readConcertoURL() error {
 	return nil
 }
 
-// readConcertoURL reads URL from CONCERTO_URL envrionment or calculates using API URL
+// readConcertoURL reads URL from CONCERTO_URL environment or calculates using API URL
 func (config *Config) readBrownfieldToken(c *cli.Context) error {
 	if config.BrownfieldToken != "" {
 		return nil

--- a/utils/format/textformatter.go
+++ b/utils/format/textformatter.go
@@ -64,7 +64,7 @@ func (f *TextFormatter) printItemAux(w *tabwriter.Writer, item interface{}) erro
 						fmt.Fprintf(w, fmt.Sprintf("%s:\t", it.Type().Field(i).Tag.Get("header")))
 						chunks := make([]string, 0)
 						for _, mapVal := range it.Field(i).MapKeys() {
-							itVal := reflect.ValueOf(it.Field(i).MapIndex(mapVal).Interface())
+							itVal := reflect.ValueOf(it.Field(i).MapIndex(mapVal).Interface()).Elem()
 							for k := 0; k < itVal.NumField(); k++ {
 								sTags := strings.Split(itVal.Type().Field(k).Tag.Get("show"), ",")
 								if !utils.Contains(sTags, "noshow") {


### PR DESCRIPTION
Closes #45
- avoid using json.RawMessage
- User mode blueprint templates reorder-template-scripts: "--script-ids", as comma separated:

> --script-ids 5cc2dd7fa9dd7d0901418243,5cc2ddcda9dd7d0901418241

instead of

> --script-ids '["5c8a4304b544c20900eb2d2c","5cb747a4746c7909009bd68c"]'
   		
- User mode blueprint templates [create|update]: "--run-list", "--cookbook-versions", "--configuration-attributes" , "--configuration-attributes-from-file"
> 
	--run-list value                        A list of comma separated cookbook recipes that is run on the servers at start-up, i.e: --run-list "imco::firewall,1password,joomla"    	
	--cookbook-versions value               The cookbook versions used to configure the service recipes in the run-list, i.e: --cookbook-versions "imco:3.0.3,1password~>1.3.0,joomla:0.11.0" 
                                             	Cookbook version format: [NAME<OPERATOR>VERSION] 
                                             	Supported Operators:
                                               Chef supermarket cookbook '~>','=','>=','>','<','<='
                                               Uploaded cookbook ':'
 	--configuration-attributes value         The attributes used to configure the service recipes in the run-list, as a json formatted parameter. i.e: --configuration-attributes '{"joomla":{"db":{"password":"my_pass"},"port":"8080"}}'
 	--configuration-attributes-from-file value  The attributes used to configure the service recipes in the run-list, from file or STDIN, as a json formatted parameter. 
                                             From file: --configuration-attributes-from-file attrs.json 
                                             From STDIN: --configuration-attributes-from-file -
		Sample output:
			ID:                         5cda9bd96997d609003971ad
			NAME:                       StgUbuntuTpl
			GENERIC_IMAGE_ID:           5c757a96b44c31000d43d729
			RUN_LIST:                   imco::firewall,1password,joomla
			CONFIGURATION_ATTRIBUTES:   {"joomla":{"db":{"password":"my_pass"},"port":"8080"}}
			RESOURCE_TYPE:              template
			COOKBOOK_VERSIONS:          1password~>1.3.0,imco:3.0.3,joomla:0.11.0
			STATE:                      compiling
			LABELS:                     Stagging,Ubuntu 16.04


- User mode blueprint templates [create|update]-template-script: "--parameter-values", "--parameter-values-from-file"
> 
 	--parameter-values value            A map that assigns a value to each script parameter, as a json formatted parameter; i.e: '{"param1":"val1","param2":"val2"}'
 	--parameter-values-from-file value  A map that assigns a value to each script parameter, from file or STDIN, as a json formatted parameter: '{"param1":"val1","param2":"val2"}'. 
                                     		From file: --parameter-values-from-file params.json 
                                     		From STDIN: --parameter-values-from-file -

		Sample output:
			ID:                 5ccadc2f89c9240900489084
			TYPE:               operational
			EXECUTION_ORDER:    0
			TEMPLATE_ID:        5cc6b95318d8900901bdb51f
			SCRIPT_ID:          5c8a4304b544c20900eb2d2c
			PARAMETER_VALUES:   {"One":"val1","two":"val2"}

- User mode firewall profile rules:

> 
 	--rules value        Set of rules of the firewall profile, i.e: --rules TCP/8080-8081:0.0.0.0/0,TCP/9090-9091:any,UDP/3456:1.2.3.4
                     		Rule format: [PROTOCOL/MIN_PORT[-MAX_PORT]:CIDR_IP]

		Sample output:(it includes required and custom rules):
     	RULES:           TCP/22-22:any,TCP/5985-5985:any,TCP/3389-3389:any,TCP/10050-10050:any,TCP/8080-8081:any,TCP/9090-9091:any,UDP/3456-3456:1.2.3.4


<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

# Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

# Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

# How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

# Screenshots (if appropriate)

# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.