### PR TITLE
List floating ips of a server (issue #110)

### DIFF
--- a/api/cloud/servers_api.go
+++ b/api/cloud/servers_api.go
@@ -201,6 +201,26 @@ func (dm *ServerService) DeleteServer(ID string) (err error) {
 	return nil
 }
 
+// GetServerFloatingIPList returns the list of floating IPs as an array of FloatingIP
+func (dm *ServerService) GetServerFloatingIPList(serverID string) (floatingIPs []*types.FloatingIP, err error) {
+	log.Debug("GetServerFloatingIPList")
+
+	data, status, err := dm.concertoService.Get(fmt.Sprintf("/cloud/servers/%s/floating_ips", serverID))
+	if err != nil {
+		return nil, err
+	}
+
+	if err = utils.CheckStandardStatus(status, data); err != nil {
+		return nil, err
+	}
+
+	if err = json.Unmarshal(data, &floatingIPs); err != nil {
+		return nil, err
+	}
+
+	return floatingIPs, nil
+}
+
 // GetServerVolumesList returns the list of volumes as an array of Volume
 func (dm *ServerService) GetServerVolumesList(serverID string) (volumes []*types.Volume, err error) {
 	log.Debug("GetServerVolumesList")

--- a/api/cloud/servers_api_mocked.go
+++ b/api/cloud/servers_api_mocked.go
@@ -979,6 +979,107 @@ func DeleteServerFailStatusMocked(t *testing.T, serverIn *types.Server) {
 	assert.Contains(err.Error(), "499", "Error should contain http code 499")
 }
 
+// GetServerFloatingIPListMocked test mocked function
+func GetServerFloatingIPListMocked(t *testing.T, floatingIPsIn []*types.FloatingIP, serverID string) []*types.FloatingIP {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewServerService(cs)
+	assert.Nil(err, "Couldn't load server service")
+	assert.NotNil(ds, "Server service not instanced")
+
+	// to json
+	fIn, err := json.Marshal(floatingIPsIn)
+	assert.Nil(err, "Server floating IP test data corrupted")
+
+	// call service
+	cs.On("Get", fmt.Sprintf("/cloud/servers/%s/floating_ips", serverID)).Return(fIn, 200, nil)
+	floatingIPsOut, err := ds.GetServerFloatingIPList(serverID)
+	assert.Nil(err, "Error getting server floating IP list")
+	assert.Equal(floatingIPsIn, floatingIPsOut, "GetServerFloatingIPListMocked returned different server floating IPs")
+
+	return floatingIPsOut
+}
+
+// GetServerFloatingIPListFailErrMocked test mocked function
+func GetServerFloatingIPListFailErrMocked(t *testing.T, floatingIPsIn []*types.FloatingIP, serverID string) []*types.FloatingIP {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewServerService(cs)
+	assert.Nil(err, "Couldn't load server service")
+	assert.NotNil(ds, "Server service not instanced")
+
+	// to json
+	fIn, err := json.Marshal(floatingIPsIn)
+	assert.Nil(err, "Server floating IP test data corrupted")
+
+	// call service
+	cs.On("Get", fmt.Sprintf("/cloud/servers/%s/floating_ips", serverID)).Return(fIn, 200, fmt.Errorf("mocked error"))
+	floatingIPsOut, err := ds.GetServerFloatingIPList(serverID)
+
+	assert.NotNil(err, "We are expecting an error")
+	assert.Nil(floatingIPsOut, "Expecting nil output")
+	assert.Equal(err.Error(), "mocked error", "Error should be 'mocked error'")
+
+	return floatingIPsOut
+}
+
+// GetServerFloatingIPListFailStatusMocked test mocked function
+func GetServerFloatingIPListFailStatusMocked(t *testing.T, floatingIPsIn []*types.FloatingIP, serverID string) []*types.FloatingIP {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewServerService(cs)
+	assert.Nil(err, "Couldn't load server service")
+	assert.NotNil(ds, "Server service not instanced")
+
+	// to json
+	fIn, err := json.Marshal(floatingIPsIn)
+	assert.Nil(err, "Server floating IP test data corrupted")
+
+	// call service
+	cs.On("Get", fmt.Sprintf("/cloud/servers/%s/floating_ips", serverID)).Return(fIn, 499, nil)
+	floatingIPsOut, err := ds.GetServerFloatingIPList(serverID)
+
+	assert.NotNil(err, "We are expecting an status code error")
+	assert.Nil(floatingIPsOut, "Expecting nil output")
+	assert.Contains(err.Error(), "499", "Error should contain http code 499")
+
+	return floatingIPsOut
+}
+
+// GetServerFloatingIPListFailJSONMocked test mocked function
+func GetServerFloatingIPListFailJSONMocked(t *testing.T, floatingIPsIn []*types.FloatingIP, serverID string) []*types.FloatingIP {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewServerService(cs)
+	assert.Nil(err, "Couldn't load server service")
+	assert.NotNil(ds, "Server service not instanced")
+
+	// wrong json
+	fIn := []byte{10, 20, 30}
+
+	// call service
+	cs.On("Get", fmt.Sprintf("/cloud/servers/%s/floating_ips", serverID)).Return(fIn, 200, nil)
+	floatingIPsOut, err := ds.GetServerFloatingIPList(serverID)
+
+	assert.NotNil(err, "We are expecting a marshalling error")
+	assert.Nil(floatingIPsOut, "Expecting nil output")
+	assert.Contains(err.Error(), "invalid character", "Error message should include the string 'invalid character'")
+
+	return floatingIPsOut
+}
+
 // GetServerVolumesListMocked test mocked function
 func GetServerVolumesListMocked(t *testing.T, volumesIn []*types.Volume, serverID string) []*types.Volume {
 

--- a/api/cloud/servers_api_test.go
+++ b/api/cloud/servers_api_test.go
@@ -102,6 +102,17 @@ func TestDeleteServer(t *testing.T) {
 	}
 }
 
+func TestGetServerFloatingIPList(t *testing.T) {
+	serversIn := testdata.GetServerData()
+	floatingIPsIn := testdata.GetFloatingIPData()
+	for _, serverIn := range serversIn {
+		GetServerFloatingIPListMocked(t, floatingIPsIn, serverIn.ID)
+		GetServerFloatingIPListFailErrMocked(t, floatingIPsIn, serverIn.ID)
+		GetServerFloatingIPListFailStatusMocked(t, floatingIPsIn, serverIn.ID)
+		GetServerFloatingIPListFailJSONMocked(t, floatingIPsIn, serverIn.ID)
+	}
+}
+
 func TestGetServerVolumesList(t *testing.T) {
 	serversIn := testdata.GetServerData()
 	volumesIn := testdata.GetVolumeData()

--- a/cloud/servers/subcommands.go
+++ b/cloud/servers/subcommands.go
@@ -173,6 +173,17 @@ func SubCommands() []cli.Command {
 			},
 		},
 		{
+			Name:   "list-floating-ips",
+			Usage:  "This action returns information about the floating IPs attached to the server with the given id",
+			Action: cmd.ServerFloatingIPList,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "id",
+					Usage: "Server Id",
+				},
+			},
+		},
+		{
 			Name:   "list-volumes",
 			Usage:  "This action returns information about the volumes attached to the server with the given id",
 			Action: cmd.ServerVolumesList,


### PR DESCRIPTION
Closes #110

New Server command to retrieve attached Floating IPs:
= > **concerto cloud:**
- **servers**
![imagen](https://user-images.githubusercontent.com/22797797/58631588-56fb2f00-82e3-11e9-85b4-e42a17575158.png)


  list-floating-ips -> GET /v2/cloud/servers/:server_id/floating_ips

<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

# Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

# Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

# How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

# Screenshots (if appropriate)

# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.