### PR TITLE
Allow show Cloud Account details (issue #112)

### DIFF
--- a/api/settings/cloud_accounts_api.go
+++ b/api/settings/cloud_accounts_api.go
@@ -44,3 +44,23 @@ func (ca *CloudAccountService) GetCloudAccountList() (cloudAccounts []*types.Clo
 
 	return cloudAccounts, nil
 }
+
+// GetCloudAccount returns a cloudAccount by its ID
+func (ca *CloudAccountService) GetCloudAccount(cloudAccountID string) (cloudAccount *types.CloudAccount, err error) {
+	log.Debug("GetCloudAccount")
+
+	data, status, err := ca.concertoService.Get(fmt.Sprintf("/settings/cloud_accounts/%s", cloudAccountID))
+	if err != nil {
+		return nil, err
+	}
+
+	if err = utils.CheckStandardStatus(status, data); err != nil {
+		return nil, err
+	}
+
+	if err = json.Unmarshal(data, &cloudAccount); err != nil {
+		return nil, err
+	}
+
+	return cloudAccount, nil
+}

--- a/api/settings/cloud_accounts_api_mocked.go
+++ b/api/settings/cloud_accounts_api_mocked.go
@@ -19,19 +19,19 @@ func GetCloudAccountListMocked(t *testing.T, cloudAccountsIn []*types.CloudAccou
 
 	// wire up
 	cs := &utils.MockConcertoService{}
-	clAccService, err := NewCloudAccountService(cs)
-	assert.Nil(err, "Couldn't load cloudAccount service")
-	assert.NotNil(clAccService, "CloudAccount service not instanced")
+	ds, err := NewCloudAccountService(cs)
+	assert.Nil(err, "Couldn't load cloud account service")
+	assert.NotNil(ds, "Cloud account service not instanced")
 
 	// to json
 	dIn, err := json.Marshal(cloudAccountsIn)
-	assert.Nil(err, "CloudAccount test data corrupted")
+	assert.Nil(err, "Cloud account test data corrupted")
 
 	// call service
 	cs.On("Get", "/settings/cloud_accounts").Return(dIn, 200, nil)
-	cloudAccountsOut, err := clAccService.GetCloudAccountList()
-	assert.Nil(err, "Error getting cloudAccount list")
-	assert.Equal(cloudAccountsIn, cloudAccountsOut, "GetCloudAccountList returned different cloudAccounts")
+	cloudAccountsOut, err := ds.GetCloudAccountList()
+	assert.Nil(err, "Error getting cloud account list")
+	assert.Equal(cloudAccountsIn, cloudAccountsOut, "GetCloudAccountList returned different cloud accounts")
 
 	return cloudAccountsOut
 }
@@ -43,17 +43,17 @@ func GetCloudAccountListFailErrMocked(t *testing.T, cloudAccountsIn []*types.Clo
 
 	// wire up
 	cs := &utils.MockConcertoService{}
-	clAccService, err := NewCloudAccountService(cs)
-	assert.Nil(err, "Couldn't load cloudAccount service")
-	assert.NotNil(clAccService, "CloudAccount service not instanced")
+	ds, err := NewCloudAccountService(cs)
+	assert.Nil(err, "Couldn't load cloud account service")
+	assert.NotNil(ds, "Cloud account service not instanced")
 
 	// to json
 	dIn, err := json.Marshal(cloudAccountsIn)
-	assert.Nil(err, "CloudAccount test data corrupted")
+	assert.Nil(err, "Cloud account test data corrupted")
 
 	// call service
 	cs.On("Get", "/settings/cloud_accounts").Return(dIn, 200, fmt.Errorf("mocked error"))
-	cloudAccountsOut, err := clAccService.GetCloudAccountList()
+	cloudAccountsOut, err := ds.GetCloudAccountList()
 
 	assert.NotNil(err, "We are expecting an error")
 	assert.Nil(cloudAccountsOut, "Expecting nil output")
@@ -69,17 +69,17 @@ func GetCloudAccountListFailStatusMocked(t *testing.T, cloudAccountsIn []*types.
 
 	// wire up
 	cs := &utils.MockConcertoService{}
-	clAccService, err := NewCloudAccountService(cs)
-	assert.Nil(err, "Couldn't load cloudAccount service")
-	assert.NotNil(clAccService, "CloudAccount service not instanced")
+	ds, err := NewCloudAccountService(cs)
+	assert.Nil(err, "Couldn't load cloud account service")
+	assert.NotNil(ds, "Cloud account service not instanced")
 
 	// to json
 	dIn, err := json.Marshal(cloudAccountsIn)
-	assert.Nil(err, "CloudAccount test data corrupted")
+	assert.Nil(err, "Cloud account test data corrupted")
 
 	// call service
 	cs.On("Get", "/settings/cloud_accounts").Return(dIn, 499, nil)
-	cloudAccountsOut, err := clAccService.GetCloudAccountList()
+	cloudAccountsOut, err := ds.GetCloudAccountList()
 
 	assert.NotNil(err, "We are expecting an status code error")
 	assert.Nil(cloudAccountsOut, "Expecting nil output")
@@ -95,20 +95,120 @@ func GetCloudAccountListFailJSONMocked(t *testing.T, cloudAccountsIn []*types.Cl
 
 	// wire up
 	cs := &utils.MockConcertoService{}
-	clAccService, err := NewCloudAccountService(cs)
-	assert.Nil(err, "Couldn't load cloudAccount service")
-	assert.NotNil(clAccService, "CloudAccount service not instanced")
+	ds, err := NewCloudAccountService(cs)
+	assert.Nil(err, "Couldn't load cloud account service")
+	assert.NotNil(ds, "Cloud account service not instanced")
 
 	// wrong json
 	dIn := []byte{10, 20, 30}
 
 	// call service
 	cs.On("Get", "/settings/cloud_accounts").Return(dIn, 200, nil)
-	cloudAccountsOut, err := clAccService.GetCloudAccountList()
+	cloudAccountsOut, err := ds.GetCloudAccountList()
 
 	assert.NotNil(err, "We are expecting a marshalling error")
 	assert.Nil(cloudAccountsOut, "Expecting nil output")
 	assert.Contains(err.Error(), "invalid character", "Error message should include the string 'invalid character'")
 
 	return cloudAccountsOut
+}
+
+// GetCloudAccountMocked test mocked function
+func GetCloudAccountMocked(t *testing.T, cloudAccountIn *types.CloudAccount) *types.CloudAccount {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewCloudAccountService(cs)
+	assert.Nil(err, "Couldn't load cloud account service")
+	assert.NotNil(ds, "Cloud account service not instanced")
+
+	// to json
+	dIn, err := json.Marshal(cloudAccountIn)
+	assert.Nil(err, "Cloud account test data corrupted")
+
+	// call service
+	cs.On("Get", fmt.Sprintf("/settings/cloud_accounts/%s", cloudAccountIn.ID)).Return(dIn, 200, nil)
+	cloudAccountOut, err := ds.GetCloudAccount(cloudAccountIn.ID)
+	assert.Nil(err, "Error getting cloud account")
+	assert.Equal(*cloudAccountIn, *cloudAccountOut, "GetCloudAccount returned different cloud account")
+
+	return cloudAccountOut
+}
+
+// GetCloudAccountFailErrMocked test mocked function
+func GetCloudAccountFailErrMocked(t *testing.T, cloudAccountIn *types.CloudAccount) *types.CloudAccount {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewCloudAccountService(cs)
+	assert.Nil(err, "Couldn't load cloud account service")
+	assert.NotNil(ds, "Cloud account service not instanced")
+
+	// to json
+	dIn, err := json.Marshal(cloudAccountIn)
+	assert.Nil(err, "Cloud account test data corrupted")
+
+	// call service
+	cs.On("Get", fmt.Sprintf("/settings/cloud_accounts/%s", cloudAccountIn.ID)).Return(dIn, 200, fmt.Errorf("mocked error"))
+	cloudAccountOut, err := ds.GetCloudAccount(cloudAccountIn.ID)
+
+	assert.NotNil(err, "We are expecting an error")
+	assert.Nil(cloudAccountOut, "Expecting nil output")
+	assert.Equal(err.Error(), "mocked error", "Error should be 'mocked error'")
+
+	return cloudAccountOut
+}
+
+// GetCloudAccountFailStatusMocked test mocked function
+func GetCloudAccountFailStatusMocked(t *testing.T, cloudAccountIn *types.CloudAccount) *types.CloudAccount {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewCloudAccountService(cs)
+	assert.Nil(err, "Couldn't load cloud account service")
+	assert.NotNil(ds, "Cloud account service not instanced")
+
+	// to json
+	dIn, err := json.Marshal(cloudAccountIn)
+	assert.Nil(err, "Cloud account test data corrupted")
+
+	// call service
+	cs.On("Get", fmt.Sprintf("/settings/cloud_accounts/%s", cloudAccountIn.ID)).Return(dIn, 499, nil)
+	cloudAccountOut, err := ds.GetCloudAccount(cloudAccountIn.ID)
+
+	assert.NotNil(err, "We are expecting an status code error")
+	assert.Nil(cloudAccountOut, "Expecting nil output")
+	assert.Contains(err.Error(), "499", "Error should contain http code 499")
+
+	return cloudAccountOut
+}
+
+// GetCloudAccountFailJSONMocked test mocked function
+func GetCloudAccountFailJSONMocked(t *testing.T, cloudAccountIn *types.CloudAccount) *types.CloudAccount {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewCloudAccountService(cs)
+	assert.Nil(err, "Couldn't load cloud account service")
+	assert.NotNil(ds, "Cloud account service not instanced")
+
+	// wrong json
+	dIn := []byte{10, 20, 30}
+
+	// call service
+	cs.On("Get", fmt.Sprintf("/settings/cloud_accounts/%s", cloudAccountIn.ID)).Return(dIn, 200, nil)
+	cloudAccountOut, err := ds.GetCloudAccount(cloudAccountIn.ID)
+	assert.NotNil(err, "We are expecting a marshalling error")
+	assert.Nil(cloudAccountOut, "Expecting nil output")
+	assert.Contains(err.Error(), "invalid character", "Error message should include the string 'invalid character'")
+
+	return cloudAccountOut
 }

--- a/api/settings/cloud_accounts_api_test.go
+++ b/api/settings/cloud_accounts_api_test.go
@@ -21,3 +21,13 @@ func TestGetCloudAccountList(t *testing.T) {
 	GetCloudAccountListFailStatusMocked(t, cloudAccountsIn)
 	GetCloudAccountListFailJSONMocked(t, cloudAccountsIn)
 }
+
+func TestGetCloudAccount(t *testing.T) {
+	cloudAccountsIn := testdata.GetCloudAccountData()
+	for _, cloudAccountIn := range cloudAccountsIn {
+		GetCloudAccountMocked(t, cloudAccountIn)
+		GetCloudAccountFailErrMocked(t, cloudAccountIn)
+		GetCloudAccountFailStatusMocked(t, cloudAccountIn)
+		GetCloudAccountFailJSONMocked(t, cloudAccountIn)
+	}
+}

--- a/api/types/cloud_accounts.go
+++ b/api/types/cloud_accounts.go
@@ -1,10 +1,18 @@
 package types
 
+import "time"
+
 type CloudAccount struct {
-	ID                string `json:"id" header:"ID"`
-	Name              string `json:"name" header:"NAME"`
-	CloudProviderID   string `json:"cloud_provider_id" header:"CLOUD_PROVIDER_ID"`
-	CloudProviderName string `json:"cloud_provider_name" header:"CLOUD_PROVIDER_NAME"`
+	ID                           string    `json:"id" header:"ID"`
+	Name                         string    `json:"name" header:"NAME"`
+	CloudProviderID              string    `json:"cloud_provider_id" header:"CLOUD_PROVIDER_ID"`
+	CloudProviderName            string    `header:"CLOUD_PROVIDER_NAME"`
+	SupportsImporting            bool      `json:"supports_importing" header:"SUPPORTS_IMPORTING" show:"nolist"`
+	SupportsImportingVPCs        bool      `json:"supports_importing_vpcs" header:"SUPPORTS_IMPORTING_VPCS" show:"nolist"`
+	SupportsImportingFloatingIPs bool      `json:"supports_importing_floating_ips" header:"SUPPORTS_IMPORTING_FLOATING_IPS" show:"nolist"`
+	LastDiscoveredAt             time.Time `json:"last_discovered_at" header:"LAST_DISCOVERED" show:"nolist"`
+	LastDiscoveredFailedAt       time.Time `json:"last_discovery_failed_at" header:"LAST_DISCOVERED_FAILED" show:"nolist"`
+	ResourceType                 string    `json:"resource_type" header:"RESOURCE_TYPE" show:"nolist"`
 }
 
 type RequiredCredentials interface{}

--- a/cmd/cloud_accounts_cmd.go
+++ b/cmd/cloud_accounts_cmd.go
@@ -50,3 +50,24 @@ func CloudAccountList(c *cli.Context) error {
 
 	return nil
 }
+
+// CloudAccountShow subcommand function
+func CloudAccountShow(c *cli.Context) error {
+	debugCmdFuncInfo(c)
+	cloudAccountSvc, formatter := WireUpCloudAccount(c)
+
+	checkRequiredFlags(c, []string{"id"}, formatter)
+	cloudAccount, err := cloudAccountSvc.GetCloudAccount(c.String("id"))
+	if err != nil {
+		formatter.PrintFatal("Couldn't receive cloudAccount data", err)
+	}
+
+	cloudProvidersMap := LoadCloudProvidersMapping(c)
+
+	cloudAccount.CloudProviderName = cloudProvidersMap[cloudAccount.CloudProviderID]
+
+	if err = formatter.PrintItem(*cloudAccount); err != nil {
+		formatter.PrintFatal("Couldn't print/format result", err)
+	}
+	return nil
+}

--- a/settings/cloud_accounts/subcommands.go
+++ b/settings/cloud_accounts/subcommands.go
@@ -13,5 +13,16 @@ func SubCommands() []cli.Command {
 			Usage:  "Lists the cloud accounts of the account group.",
 			Action: cmd.CloudAccountList,
 		},
+		{
+			Name:   "show",
+			Usage:  "Shows information about a specific cloud account",
+			Action: cmd.CloudAccountShow,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "id",
+					Usage: "Cloud Account Id",
+				},
+			},
+		},
 	}
 }


### PR DESCRIPTION
Closes #112

New _Cloud Accounts_ command to show details:
![imagen](https://user-images.githubusercontent.com/22797797/58643679-0b0ab300-8300-11e9-92a8-9c916ef3a536.png)

**concerto settings cloud-accounts show --id (CLOUD_ACCOUNT_ID)** => /v2/settings/cloud_accounts/:CLOUD_ACCOUNT_ID
<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

# Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

# Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

# How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

# Screenshots (if appropriate)

# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.