### PR TITLE
Use delete better than destroy (issue #119)

### DIFF
--- a/cloud/server_arrays/subcommands.go
+++ b/cloud/server_arrays/subcommands.go
@@ -152,8 +152,8 @@ func SubCommands() []cli.Command {
 			},
 		},
 		{
-			Name:   "destroy",
-			Usage:  "This action destroys the server array with the given id. This action will only be allowed if the server array is empty",
+			Name:   "delete",
+			Usage:  "This action decommissions the server array with the given id. This action will only be allowed if the server array is empty",
 			Action: cmd.ServerArrayDelete,
 			Flags: []cli.Flag{
 				cli.StringFlag{

--- a/cloud/ssh_profiles/subcommands.go
+++ b/cloud/ssh_profiles/subcommands.go
@@ -77,8 +77,8 @@ func SubCommands() []cli.Command {
 			},
 		},
 		{
-			Name:   "destroy",
-			Usage:  "Destroys an SSH profile",
+			Name:   "delete",
+			Usage:  "Deletes a SSH profile",
 			Action: cmd.SSHProfileDelete,
 			Flags: []cli.Flag{
 				cli.StringFlag{

--- a/network/firewall_profiles/subcommands.go
+++ b/network/firewall_profiles/subcommands.go
@@ -78,7 +78,7 @@ func SubCommands() []cli.Command {
 		},
 		{
 			Name:   "delete",
-			Usage:  "Destroy a firewall profile",
+			Usage:  "Deletes a firewall profile",
 			Action: cmd.FirewallProfileDelete,
 			Flags: []cli.Flag{
 				cli.StringFlag{

--- a/network/floating_ips/subcommands.go
+++ b/network/floating_ips/subcommands.go
@@ -99,7 +99,7 @@ func SubCommands() []cli.Command {
 			},
 		},
 		{
-			Name:   "destroy",
+			Name:   "delete",
 			Usage:  "Deletes a floating IP",
 			Action: cmd.FloatingIPDelete,
 			Flags: []cli.Flag{

--- a/network/vpns/subcommands.go
+++ b/network/vpns/subcommands.go
@@ -47,7 +47,7 @@ func SubCommands() []cli.Command {
 			},
 		},
 		{
-			Name:   "destroy",
+			Name:   "delete",
 			Usage:  "Deletes a VPN of the specified VPC",
 			Action: cmd.VPNDelete,
 			Flags: []cli.Flag{

--- a/storage/volumes/subcommands.go
+++ b/storage/volumes/subcommands.go
@@ -103,7 +103,7 @@ func SubCommands() []cli.Command {
 			},
 		},
 		{
-			Name:   "destroy",
+			Name:   "delete",
 			Usage:  "Deletes a volume",
 			Action: cmd.VolumeDelete,
 			Flags: []cli.Flag{


### PR DESCRIPTION
Closes #119

It is preferable to use the command action name "delete" rather than "destroy"; with this, the same action name is normalized for resources.

<!--- Provide a general summary of your changes in the Title above -->

# Description

<!--- Describe your changes in detail -->

# Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

# Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

# How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

# Screenshots (if appropriate)

# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.