### PR TITLE
Allow work with blueprint attachments (issue #121)

### DIFF
--- a/api/blueprint/attachments_api.go
+++ b/api/blueprint/attachments_api.go
@@ -1,0 +1,73 @@
+package blueprint
+
+import (
+	"encoding/json"
+	"fmt"
+	log "github.com/Sirupsen/logrus"
+	"github.com/ingrammicro/concerto/api/types"
+	"github.com/ingrammicro/concerto/utils"
+)
+
+// AttachmentService manages attachments operations
+type AttachmentService struct {
+	concertoService utils.ConcertoService
+}
+
+// NewAttachmentService returns a Concerto attachment service
+func NewAttachmentService(concertoService utils.ConcertoService) (*AttachmentService, error) {
+	if concertoService == nil {
+		return nil, fmt.Errorf("must initialize ConcertoService before using it")
+	}
+
+	return &AttachmentService{
+		concertoService: concertoService,
+	}, nil
+}
+
+// GetAttachment returns a attachment by its ID
+func (as *AttachmentService) GetAttachment(attachmentID string) (attachment *types.Attachment, err error) {
+	log.Debug("GetAttachment")
+
+	data, status, err := as.concertoService.Get(fmt.Sprintf("/blueprint/attachments/%s", attachmentID))
+	if err != nil {
+		return nil, err
+	}
+
+	if err = utils.CheckStandardStatus(status, data); err != nil {
+		return nil, err
+	}
+
+	if err = json.Unmarshal(data, &attachment); err != nil {
+		return nil, err
+	}
+
+	return attachment, nil
+}
+
+// DownloadAttachment gets an attachment file from given url saving file into given file path
+func (as *AttachmentService) DownloadAttachment(url string, filePath string) (realFileName string, status int, err error) {
+	log.Debug("DownloadAttachment")
+
+	realFileName, status, err = as.concertoService.GetFile(url, filePath, false)
+	if err != nil {
+		return realFileName, status, err
+	}
+
+	return realFileName, status, nil
+}
+
+// DeleteAttachment deletes a attachment by its ID
+func (as *AttachmentService) DeleteAttachment(attachmentID string) (err error) {
+	log.Debug("DeleteAttachment")
+
+	data, status, err := as.concertoService.Delete(fmt.Sprintf("/blueprint/attachments/%s", attachmentID))
+	if err != nil {
+		return err
+	}
+
+	if err = utils.CheckStandardStatus(status, data); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/api/blueprint/attachments_api_mocked.go
+++ b/api/blueprint/attachments_api_mocked.go
@@ -1,0 +1,225 @@
+package blueprint
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/ingrammicro/concerto/api/types"
+	"github.com/ingrammicro/concerto/utils"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+// TODO exclude from release compile
+
+// GetAttachmentMocked test mocked function
+func GetAttachmentMocked(t *testing.T, attachmentIn *types.Attachment) *types.Attachment {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewAttachmentService(cs)
+	assert.Nil(err, "Couldn't load attachment service")
+	assert.NotNil(ds, "Attachment service not instanced")
+
+	// to json
+	dIn, err := json.Marshal(attachmentIn)
+	assert.Nil(err, "Attachment test data corrupted")
+
+	// call service
+	cs.On("Get", fmt.Sprintf("/blueprint/attachments/%s", attachmentIn.ID)).Return(dIn, 200, nil)
+	attachmentOut, err := ds.GetAttachment(attachmentIn.ID)
+	assert.Nil(err, "Error getting attachment")
+	assert.Equal(*attachmentIn, *attachmentOut, "GetAttachment returned different attachments")
+
+	return attachmentOut
+}
+
+// GetAttachmentFailErrMocked test mocked function
+func GetAttachmentFailErrMocked(t *testing.T, attachmentIn *types.Attachment) *types.Attachment {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewAttachmentService(cs)
+	assert.Nil(err, "Couldn't load attachment service")
+	assert.NotNil(ds, "Attachment service not instanced")
+
+	// to json
+	dIn, err := json.Marshal(attachmentIn)
+	assert.Nil(err, "Attachment test data corrupted")
+
+	// call service
+	cs.On("Get", fmt.Sprintf("/blueprint/attachments/%s", attachmentIn.ID)).Return(dIn, 200, fmt.Errorf("mocked error"))
+	attachmentOut, err := ds.GetAttachment(attachmentIn.ID)
+
+	assert.NotNil(err, "We are expecting an error")
+	assert.Nil(attachmentOut, "Expecting nil output")
+	assert.Equal(err.Error(), "mocked error", "Error should be 'mocked error'")
+
+	return attachmentOut
+}
+
+// GetAttachmentFailStatusMocked test mocked function
+func GetAttachmentFailStatusMocked(t *testing.T, attachmentIn *types.Attachment) *types.Attachment {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewAttachmentService(cs)
+	assert.Nil(err, "Couldn't load attachment service")
+	assert.NotNil(ds, "Attachment service not instanced")
+
+	// to json
+	dIn, err := json.Marshal(attachmentIn)
+	assert.Nil(err, "Attachment test data corrupted")
+
+	// call service
+	cs.On("Get", fmt.Sprintf("/blueprint/attachments/%s", attachmentIn.ID)).Return(dIn, 499, nil)
+	attachmentOut, err := ds.GetAttachment(attachmentIn.ID)
+
+	assert.NotNil(err, "We are expecting an status code error")
+	assert.Nil(attachmentOut, "Expecting nil output")
+	assert.Contains(err.Error(), "499", "Error should contain http code 499")
+
+	return attachmentOut
+}
+
+// GetAttachmentFailJSONMocked test mocked function
+func GetAttachmentFailJSONMocked(t *testing.T, attachmentIn *types.Attachment) *types.Attachment {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewAttachmentService(cs)
+	assert.Nil(err, "Couldn't load attachment service")
+	assert.NotNil(ds, "Attachment service not instanced")
+
+	// wrong json
+	dIn := []byte{10, 20, 30}
+
+	// call service
+	cs.On("Get", fmt.Sprintf("/blueprint/attachments/%s", attachmentIn.ID)).Return(dIn, 200, nil)
+	attachmentOut, err := ds.GetAttachment(attachmentIn.ID)
+
+	assert.NotNil(err, "We are expecting a marshalling error")
+	assert.Nil(attachmentOut, "Expecting nil output")
+	assert.Contains(err.Error(), "invalid character", "Error message should include the string 'invalid character'")
+
+	return attachmentOut
+}
+
+// DownloadAttachmentMocked test mocked function
+func DownloadAttachmentMocked(t *testing.T, dataIn map[string]string) {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewAttachmentService(cs)
+	assert.Nil(err, "Couldn't load attachment service")
+	assert.NotNil(ds, "Attachment service not instanced")
+
+	urlSource := dataIn["fakeEndpoint"]
+	pathFile := dataIn["fakeAttachmentDir"]
+
+	// call service
+	cs.On("GetFile", urlSource, pathFile).Return(pathFile, 200, nil)
+	realFileName, status, err := ds.DownloadAttachment(urlSource, pathFile)
+	assert.Nil(err, "Error downloading attachment file")
+	assert.Equal(status, 200, "DownloadAttachment returned invalid response")
+	assert.Equal(realFileName, pathFile, "Invalid downloaded file path")
+}
+
+// DownloadAttachmentFailErrMocked test mocked function
+func DownloadAttachmentFailErrMocked(t *testing.T, dataIn map[string]string) {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewAttachmentService(cs)
+	assert.Nil(err, "Couldn't load attachment service")
+	assert.NotNil(ds, "Attachment service not instanced")
+
+	urlSource := dataIn["fakeEndpoint"]
+	pathFile := dataIn["fakeAttachmentDir"]
+
+	// call service
+	cs.On("GetFile", urlSource, pathFile).Return("", 499, fmt.Errorf("mocked error"))
+	_, status, err := ds.DownloadAttachment(urlSource, pathFile)
+	assert.NotNil(err, "We are expecting an error")
+	assert.Equal(status, 499, "DownloadAttachment returned an unexpected status code")
+	assert.Equal(err.Error(), "mocked error", "Error should be 'mocked error'")
+}
+
+// DeleteAttachmentMocked test mocked function
+func DeleteAttachmentMocked(t *testing.T, attachmentIn *types.Attachment) {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewAttachmentService(cs)
+	assert.Nil(err, "Couldn't load attachment service")
+	assert.NotNil(ds, "Attachment service not instanced")
+
+	// to json
+	dIn, err := json.Marshal(attachmentIn)
+	assert.Nil(err, "Attachment test data corrupted")
+
+	// call service
+	cs.On("Delete", fmt.Sprintf("/blueprint/attachments/%s", attachmentIn.ID)).Return(dIn, 200, nil)
+	err = ds.DeleteAttachment(attachmentIn.ID)
+	assert.Nil(err, "Error deleting attachment")
+
+}
+
+// DeleteAttachmentFailErrMocked test mocked function
+func DeleteAttachmentFailErrMocked(t *testing.T, attachmentIn *types.Attachment) {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewAttachmentService(cs)
+	assert.Nil(err, "Couldn't load attachment service")
+	assert.NotNil(ds, "Attachment service not instanced")
+
+	// to json
+	dIn, err := json.Marshal(attachmentIn)
+	assert.Nil(err, "Attachment test data corrupted")
+
+	// call service
+	cs.On("Delete", fmt.Sprintf("/blueprint/attachments/%s", attachmentIn.ID)).Return(dIn, 200, fmt.Errorf("mocked error"))
+	err = ds.DeleteAttachment(attachmentIn.ID)
+
+	assert.NotNil(err, "We are expecting an error")
+	assert.Equal(err.Error(), "mocked error", "Error should be 'mocked error'")
+}
+
+// DeleteAttachmentFailStatusMocked test mocked function
+func DeleteAttachmentFailStatusMocked(t *testing.T, attachmentIn *types.Attachment) {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewAttachmentService(cs)
+	assert.Nil(err, "Couldn't load attachment service")
+	assert.NotNil(ds, "Attachment service not instanced")
+
+	// to json
+	dIn, err := json.Marshal(attachmentIn)
+	assert.Nil(err, "Attachment test data corrupted")
+
+	// call service
+	cs.On("Delete", fmt.Sprintf("/blueprint/attachments/%s", attachmentIn.ID)).Return(dIn, 499, nil)
+	err = ds.DeleteAttachment(attachmentIn.ID)
+
+	assert.NotNil(err, "We are expecting an status code error")
+	assert.Contains(err.Error(), "499", "Error should contain http code 499")
+}

--- a/api/blueprint/attachments_api_test.go
+++ b/api/blueprint/attachments_api_test.go
@@ -1,0 +1,39 @@
+package blueprint
+
+import (
+	"github.com/ingrammicro/concerto/testdata"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNewAttachmentServiceNil(t *testing.T) {
+	assert := assert.New(t)
+	rs, err := NewAttachmentService(nil)
+	assert.Nil(rs, "Uninitialized service should return nil")
+	assert.NotNil(err, "Uninitialized service should return error")
+}
+
+func TestGetAttachment(t *testing.T) {
+	attachmentsIn := testdata.GetAttachmentData()
+	for _, attachmentIn := range attachmentsIn {
+		GetAttachmentMocked(t, attachmentIn)
+		GetAttachmentFailErrMocked(t, attachmentIn)
+		GetAttachmentFailStatusMocked(t, attachmentIn)
+		GetAttachmentFailJSONMocked(t, attachmentIn)
+	}
+}
+
+func TestDownloadAttachment(t *testing.T) {
+	dataIn := testdata.GetDownloadAttachmentData()
+	DownloadAttachmentMocked(t, dataIn)
+	DownloadAttachmentFailErrMocked(t, dataIn)
+}
+
+func TestDeleteAttachment(t *testing.T) {
+	attachmentsIn := testdata.GetAttachmentData()
+	for _, attachmentIn := range attachmentsIn {
+		DeleteAttachmentMocked(t, attachmentIn)
+		DeleteAttachmentFailErrMocked(t, attachmentIn)
+		DeleteAttachmentFailStatusMocked(t, attachmentIn)
+	}
+}

--- a/api/blueprint/scripts_api.go
+++ b/api/blueprint/scripts_api.go
@@ -45,10 +45,10 @@ func (sc *ScriptService) GetScriptList() (scripts []*types.Script, err error) {
 }
 
 // GetScript returns a script by its ID
-func (sc *ScriptService) GetScript(ID string) (script *types.Script, err error) {
+func (sc *ScriptService) GetScript(scriptID string) (script *types.Script, err error) {
 	log.Debug("GetScript")
 
-	data, status, err := sc.concertoService.Get(fmt.Sprintf("/blueprint/scripts/%s", ID))
+	data, status, err := sc.concertoService.Get(fmt.Sprintf("/blueprint/scripts/%s", scriptID))
 	if err != nil {
 		return nil, err
 	}
@@ -85,10 +85,10 @@ func (sc *ScriptService) CreateScript(scriptVector *map[string]interface{}) (scr
 }
 
 // UpdateScript updates a script by its ID
-func (sc *ScriptService) UpdateScript(scriptVector *map[string]interface{}, ID string) (script *types.Script, err error) {
+func (sc *ScriptService) UpdateScript(scriptVector *map[string]interface{}, scriptID string) (script *types.Script, err error) {
 	log.Debug("UpdateScript")
 
-	data, status, err := sc.concertoService.Put(fmt.Sprintf("/blueprint/scripts/%s", ID), scriptVector)
+	data, status, err := sc.concertoService.Put(fmt.Sprintf("/blueprint/scripts/%s", scriptID), scriptVector)
 	if err != nil {
 		return nil, err
 	}
@@ -105,10 +105,10 @@ func (sc *ScriptService) UpdateScript(scriptVector *map[string]interface{}, ID s
 }
 
 // DeleteScript deletes a script by its ID
-func (sc *ScriptService) DeleteScript(ID string) (err error) {
+func (sc *ScriptService) DeleteScript(scriptID string) (err error) {
 	log.Debug("DeleteScript")
 
-	data, status, err := sc.concertoService.Delete(fmt.Sprintf("/blueprint/scripts/%s", ID))
+	data, status, err := sc.concertoService.Delete(fmt.Sprintf("/blueprint/scripts/%s", scriptID))
 	if err != nil {
 		return err
 	}
@@ -118,4 +118,80 @@ func (sc *ScriptService) DeleteScript(ID string) (err error) {
 	}
 
 	return nil
+}
+
+// AddScriptAttachment adds an attachment to script by its ID
+func (sc *ScriptService) AddScriptAttachment(attachmentIn *map[string]interface{}, scriptID string) (script *types.Attachment, err error) {
+	log.Debug("AddScriptAttachment")
+
+	data, status, err := sc.concertoService.Post(fmt.Sprintf("/blueprint/scripts/%s/attachments", scriptID), attachmentIn)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = utils.CheckStandardStatus(status, data); err != nil {
+		return nil, err
+	}
+
+	if err = json.Unmarshal(data, &script); err != nil {
+		return nil, err
+	}
+
+	return script, nil
+}
+
+// UploadScriptAttachment uploads an attachment file
+func (sc *ScriptService) UploadScriptAttachment(sourceFilePath string, targetURL string) error {
+	log.Debug("UploadScriptAttachment")
+
+	data, status, err := sc.concertoService.PutFile(sourceFilePath, targetURL)
+	if err != nil {
+		return err
+	}
+
+	if err = utils.CheckStandardStatus(status, data); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UploadedScriptAttachment sets "uploaded" status to the attachment by its ID
+func (sc *ScriptService) UploadedScriptAttachment(attachmentVector *map[string]interface{}, attachmentID string) (attachment *types.Attachment, err error) {
+	log.Debug("UploadedScriptAttachment")
+
+	data, status, err := sc.concertoService.Put(fmt.Sprintf("/blueprint/attachments/%s/uploaded", attachmentID), attachmentVector)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = utils.CheckStandardStatus(status, data); err != nil {
+		return nil, err
+	}
+
+	if err = json.Unmarshal(data, &attachment); err != nil {
+		return nil, err
+	}
+
+	return attachment, nil
+}
+
+// ListScriptAttachments returns the list of Attachments for a given script ID
+func (sc *ScriptService) ListScriptAttachments(scriptID string) (attachments []*types.Attachment, err error) {
+	log.Debug("ListScriptAttachments")
+
+	data, status, err := sc.concertoService.Get(fmt.Sprintf("/blueprint/scripts/%s/attachments", scriptID))
+	if err != nil {
+		return nil, err
+	}
+
+	if err = utils.CheckStandardStatus(status, data); err != nil {
+		return nil, err
+	}
+
+	if err = json.Unmarshal(data, &attachments); err != nil {
+		return nil, err
+	}
+
+	return attachments, nil
 }

--- a/api/blueprint/scripts_api_mocked.go
+++ b/api/blueprint/scripts_api_mocked.go
@@ -513,3 +513,398 @@ func DeleteScriptFailStatusMocked(t *testing.T, scriptIn *types.Script) {
 	assert.NotNil(err, "We are expecting an status code error")
 	assert.Contains(err.Error(), "499", "Error should contain http code 499")
 }
+
+// AddScriptAttachmentMocked test mocked function
+func AddScriptAttachmentMocked(t *testing.T, attachmentIn *types.Attachment, scriptID string) *types.Attachment {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewScriptService(cs)
+	assert.Nil(err, "Couldn't load script service")
+	assert.NotNil(ds, "Script service not instanced")
+
+	// convertMap
+	mapIn, err := utils.ItemConvertParams(*attachmentIn)
+	assert.Nil(err, "Script test data corrupted")
+
+	// to json
+	dIn, err := json.Marshal(attachmentIn)
+	assert.Nil(err, "Script test data corrupted")
+
+	// call service
+	cs.On("Post", fmt.Sprintf("/blueprint/scripts/%s/attachments", scriptID), mapIn).Return(dIn, 200, nil)
+	attachmentOut, err := ds.AddScriptAttachment(mapIn, scriptID)
+	assert.Nil(err, "Error getting template list")
+	assert.Equal(attachmentIn, attachmentOut, "AddScriptAttachment returned different attachments")
+
+	return attachmentOut
+}
+
+// AddScriptAttachmentFailErrMocked test mocked function
+func AddScriptAttachmentFailErrMocked(t *testing.T, attachmentIn *types.Attachment, scriptID string) *types.Attachment {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewScriptService(cs)
+	assert.Nil(err, "Couldn't load script service")
+	assert.NotNil(ds, "Script service not instanced")
+
+	// convertMap
+	mapIn, err := utils.ItemConvertParams(*attachmentIn)
+	assert.Nil(err, "Script test data corrupted")
+
+	// to json
+	dIn, err := json.Marshal(attachmentIn)
+	assert.Nil(err, "Script test data corrupted")
+
+	// call service
+	cs.On("Post", fmt.Sprintf("/blueprint/scripts/%s/attachments", scriptID), mapIn).Return(dIn, 200, fmt.Errorf("mocked error"))
+	attachmentOut, err := ds.AddScriptAttachment(mapIn, scriptID)
+	assert.NotNil(err, "We are expecting an error")
+	assert.Nil(attachmentOut, "Expecting nil output")
+	assert.Equal(err.Error(), "mocked error", "Error should be 'mocked error'")
+
+	return attachmentOut
+}
+
+// AddScriptAttachmentFailStatusMocked test mocked function
+func AddScriptAttachmentFailStatusMocked(t *testing.T, attachmentIn *types.Attachment, scriptID string) *types.Attachment {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewScriptService(cs)
+	assert.Nil(err, "Couldn't load script service")
+	assert.NotNil(ds, "Script service not instanced")
+
+	// convertMap
+	mapIn, err := utils.ItemConvertParams(*attachmentIn)
+	assert.Nil(err, "Script test data corrupted")
+
+	// to json
+	dIn, err := json.Marshal(attachmentIn)
+	assert.Nil(err, "Script test data corrupted")
+
+	// call service
+	cs.On("Post", fmt.Sprintf("/blueprint/scripts/%s/attachments", scriptID), mapIn).Return(dIn, 499, nil)
+	attachmentOut, err := ds.AddScriptAttachment(mapIn, scriptID)
+	assert.NotNil(err, "We are expecting an status code error")
+	assert.Nil(attachmentOut, "Expecting nil output")
+	assert.Contains(err.Error(), "499", "Error should contain http code 499")
+
+	return attachmentOut
+}
+
+// AddScriptAttachmentFailJSONMocked test mocked function
+func AddScriptAttachmentFailJSONMocked(t *testing.T, attachmentIn *types.Attachment, scriptID string) *types.Attachment {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewScriptService(cs)
+	assert.Nil(err, "Couldn't load script service")
+	assert.NotNil(ds, "Script service not instanced")
+
+	// convertMap
+	mapIn, err := utils.ItemConvertParams(*attachmentIn)
+	assert.Nil(err, "Script test data corrupted")
+
+	// wrong json
+	dIn := []byte{10, 20, 30}
+
+	// call service
+	cs.On("Post", fmt.Sprintf("/blueprint/scripts/%s/attachments", scriptID), mapIn).Return(dIn, 200, nil)
+	attachmentOut, err := ds.AddScriptAttachment(mapIn, scriptID)
+	assert.NotNil(err, "We are expecting a marshalling error")
+	assert.Nil(attachmentOut, "Expecting nil output")
+	assert.Contains(err.Error(), "invalid character", "Error message should include the string 'invalid character'")
+
+	return attachmentOut
+}
+
+// UploadScriptAttachmentMocked test mocked function
+func UploadScriptAttachmentMocked(t *testing.T, attachmentIn *types.Attachment) {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewScriptService(cs)
+	assert.Nil(err, "Couldn't load script service")
+	assert.NotNil(ds, "Script service not instanced")
+
+	sourceFilePath := "fakeURLToFile"
+	targetURL := attachmentIn.UploadURL
+
+	// call service
+	var noBytes []uint8
+	cs.On("PutFile", sourceFilePath, targetURL).Return(noBytes, 200, nil)
+	err = ds.UploadScriptAttachment(sourceFilePath, targetURL)
+	assert.Nil(err, "Error uploading attachment file")
+}
+
+// UploadScriptAttachmentFailStatusMocked test mocked function
+func UploadScriptAttachmentFailStatusMocked(t *testing.T, attachmentIn *types.Attachment) {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewScriptService(cs)
+	assert.Nil(err, "Couldn't load script service")
+	assert.NotNil(ds, "Script service not instanced")
+
+	sourceFilePath := "fakeURLToFile"
+	targetURL := attachmentIn.UploadURL
+
+	// call service
+	var noBytes []uint8
+	cs.On("PutFile", sourceFilePath, targetURL).Return(noBytes, 403, nil)
+	err = ds.UploadScriptAttachment(sourceFilePath, targetURL)
+	assert.NotNil(err, "We are expecting an error")
+}
+
+// UploadScriptAttachmentFailErrMocked test mocked function
+func UploadScriptAttachmentFailErrMocked(t *testing.T, attachmentIn *types.Attachment) {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewScriptService(cs)
+	assert.Nil(err, "Couldn't load script service")
+	assert.NotNil(ds, "Script service not instanced")
+
+	sourceFilePath := "fakeURLToFile"
+	targetURL := attachmentIn.UploadURL
+
+	// call service
+	var noBytes []uint8
+	cs.On("PutFile", sourceFilePath, targetURL).Return(noBytes, 403, fmt.Errorf("mocked error"))
+	err = ds.UploadScriptAttachment(sourceFilePath, targetURL)
+	assert.NotNil(err, "We are expecting an error")
+	assert.Equal(err.Error(), "mocked error", "Error should be 'mocked error'")
+}
+
+// UploadedScriptAttachmentMocked test mocked function
+func UploadedScriptAttachmentMocked(t *testing.T, attachmentIn *types.Attachment) *types.Attachment {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewScriptService(cs)
+	assert.Nil(err, "Couldn't load script service")
+	assert.NotNil(ds, "Script service not instanced")
+
+	// convertMap
+	mapIn, err := utils.ItemConvertParams(*attachmentIn)
+	assert.Nil(err, "Script test data corrupted")
+
+	// to json
+	dIn, err := json.Marshal(attachmentIn)
+	assert.Nil(err, "Script test data corrupted")
+
+	// call service
+	cs.On("Put", fmt.Sprintf("/blueprint/attachments/%s/uploaded", attachmentIn.ID), mapIn).Return(dIn, 200, nil)
+	attachmentOut, err := ds.UploadedScriptAttachment(mapIn, attachmentIn.ID)
+	assert.Nil(err, "Error setting uploaded status to attachmentIn")
+	assert.Equal(*attachmentIn, *attachmentOut, "UploadedScriptAttachment returned different attachments")
+
+	return attachmentOut
+}
+
+// UploadedScriptAttachmentFailErrMocked test mocked function
+func UploadedScriptAttachmentFailErrMocked(t *testing.T, attachmentIn *types.Attachment) *types.Attachment {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewScriptService(cs)
+	assert.Nil(err, "Couldn't load script service")
+	assert.NotNil(ds, "Script service not instanced")
+
+	// convertMap
+	mapIn, err := utils.ItemConvertParams(*attachmentIn)
+	assert.Nil(err, "Script test data corrupted")
+
+	// to json
+	dIn, err := json.Marshal(attachmentIn)
+	assert.Nil(err, "Script test data corrupted")
+
+	// call service
+	cs.On("Put", fmt.Sprintf("/blueprint/attachments/%s/uploaded", attachmentIn.ID), mapIn).Return(dIn, 200, fmt.Errorf("mocked error"))
+	attachmentOut, err := ds.UploadedScriptAttachment(mapIn, attachmentIn.ID)
+
+	assert.NotNil(err, "We are expecting an error")
+	assert.Nil(attachmentOut, "Expecting nil output")
+	assert.Equal(err.Error(), "mocked error", "Error should be 'mocked error'")
+
+	return attachmentOut
+}
+
+// UploadedScriptAttachmentFailStatusMocked test mocked function
+func UploadedScriptAttachmentFailStatusMocked(t *testing.T, attachmentIn *types.Attachment) *types.Attachment {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewScriptService(cs)
+	assert.Nil(err, "Couldn't load script service")
+	assert.NotNil(ds, "Script service not instanced")
+
+	// convertMap
+	mapIn, err := utils.ItemConvertParams(*attachmentIn)
+	assert.Nil(err, "Script test data corrupted")
+
+	// to json
+	dIn, err := json.Marshal(attachmentIn)
+	assert.Nil(err, "Script test data corrupted")
+
+	// call service
+	cs.On("Put", fmt.Sprintf("/blueprint/attachments/%s/uploaded", attachmentIn.ID), mapIn).Return(dIn, 499, nil)
+	attachmentOut, err := ds.UploadedScriptAttachment(mapIn, attachmentIn.ID)
+
+	assert.NotNil(err, "We are expecting an status code error")
+	assert.Nil(attachmentOut, "Expecting nil output")
+	assert.Contains(err.Error(), "499", "Error should contain http code 499")
+	return attachmentOut
+}
+
+// UploadedScriptAttachmentFailJSONMocked test mocked function
+func UploadedScriptAttachmentFailJSONMocked(t *testing.T, attachmentIn *types.Attachment) *types.Attachment {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewScriptService(cs)
+	assert.Nil(err, "Couldn't load script service")
+	assert.NotNil(ds, "Script service not instanced")
+
+	// convertMap
+	mapIn, err := utils.ItemConvertParams(*attachmentIn)
+	assert.Nil(err, "Script test data corrupted")
+
+	// wrong json
+	dIn := []byte{10, 20, 30}
+
+	// call service
+	cs.On("Put", fmt.Sprintf("/blueprint/attachments/%s/uploaded", attachmentIn.ID), mapIn).Return(dIn, 200, nil)
+	attachmentOut, err := ds.UploadedScriptAttachment(mapIn, attachmentIn.ID)
+
+	assert.NotNil(err, "We are expecting a marshalling error")
+	assert.Nil(attachmentOut, "Expecting nil output")
+	assert.Contains(err.Error(), "invalid character", "Error message should include the string 'invalid character'")
+
+	return attachmentOut
+}
+
+// ListScriptAttachmentsMocked test mocked function
+func ListScriptAttachmentsMocked(t *testing.T, attachmentsIn []*types.Attachment, scriptID string) []*types.Attachment {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewScriptService(cs)
+	assert.Nil(err, "Couldn't load script service")
+	assert.NotNil(ds, "Script service not instanced")
+
+	// to json
+	dIn, err := json.Marshal(attachmentsIn)
+	assert.Nil(err, "Script test data corrupted")
+
+	// call service
+	cs.On("Get", fmt.Sprintf("/blueprint/scripts/%s/attachments", scriptID)).Return(dIn, 200, nil)
+	attachmentsOut, err := ds.ListScriptAttachments(scriptID)
+	assert.Nil(err, "Error getting script attachments list")
+	assert.Equal(attachmentsIn, attachmentsOut, "ListScriptAttachments returned different attachments")
+
+	return attachmentsOut
+}
+
+// ListScriptAttachmentsFailErrMocked test mocked function
+func ListScriptAttachmentsFailErrMocked(t *testing.T, attachmentsIn []*types.Attachment, scriptID string) []*types.Attachment {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewScriptService(cs)
+	assert.Nil(err, "Couldn't load script service")
+	assert.NotNil(ds, "Script service not instanced")
+
+	// to json
+	dIn, err := json.Marshal(attachmentsIn)
+	assert.Nil(err, "Script test data corrupted")
+
+	// call service
+	cs.On("Get", fmt.Sprintf("/blueprint/scripts/%s/attachments", scriptID)).Return(dIn, 200, fmt.Errorf("mocked error"))
+	attachmentsOut, err := ds.ListScriptAttachments(scriptID)
+
+	assert.NotNil(err, "We are expecting an error")
+	assert.Nil(attachmentsOut, "Expecting nil output")
+	assert.Equal(err.Error(), "mocked error", "Error should be 'mocked error'")
+
+	return attachmentsOut
+}
+
+// ListScriptAttachmentsFailStatusMocked test mocked function
+func ListScriptAttachmentsFailStatusMocked(t *testing.T, attachmentsIn []*types.Attachment, scriptID string) []*types.Attachment {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewScriptService(cs)
+	assert.Nil(err, "Couldn't load script service")
+	assert.NotNil(ds, "Script service not instanced")
+
+	// to json
+	dIn, err := json.Marshal(attachmentsIn)
+	assert.Nil(err, "Script test data corrupted")
+
+	// call service
+	cs.On("Get", fmt.Sprintf("/blueprint/scripts/%s/attachments", scriptID)).Return(dIn, 499, nil)
+	attachmentsOut, err := ds.ListScriptAttachments(scriptID)
+
+	assert.NotNil(err, "We are expecting an status code error")
+	assert.Nil(attachmentsOut, "Expecting nil output")
+	assert.Contains(err.Error(), "499", "Error should contain http code 499")
+
+	return attachmentsOut
+}
+
+// ListScriptAttachmentsFailJSONMocked test mocked function
+func ListScriptAttachmentsFailJSONMocked(t *testing.T, attachmentsIn []*types.Attachment, scriptID string) []*types.Attachment {
+
+	assert := assert.New(t)
+
+	// wire up
+	cs := &utils.MockConcertoService{}
+	ds, err := NewScriptService(cs)
+	assert.Nil(err, "Couldn't load script service")
+	assert.NotNil(ds, "Script service not instanced")
+
+	// wrong json
+	dIn := []byte{10, 20, 30}
+
+	// call service
+	cs.On("Get", fmt.Sprintf("/blueprint/scripts/%s/attachments", scriptID)).Return(dIn, 200, nil)
+	attachmentsOut, err := ds.ListScriptAttachments(scriptID)
+
+	assert.NotNil(err, "We are expecting a marshalling error")
+	assert.Nil(attachmentsOut, "Expecting nil output")
+	assert.Contains(err.Error(), "invalid character", "Error message should include the string 'invalid character'")
+
+	return attachmentsOut
+}

--- a/api/blueprint/scripts_api_test.go
+++ b/api/blueprint/scripts_api_test.go
@@ -59,3 +59,42 @@ func TestDeleteScript(t *testing.T) {
 		DeleteScriptFailStatusMocked(t, scriptIn)
 	}
 }
+
+func TestAddScriptAttachment(t *testing.T) {
+	attachmentsIn := testdata.GetAttachmentData()
+	scriptsIn := testdata.GetScriptData()
+	for _, attachmentIn := range attachmentsIn {
+		AddScriptAttachmentMocked(t, attachmentIn, scriptsIn[0].ID)
+		AddScriptAttachmentFailErrMocked(t, attachmentIn, scriptsIn[0].ID)
+		AddScriptAttachmentFailStatusMocked(t, attachmentIn, scriptsIn[0].ID)
+		AddScriptAttachmentFailJSONMocked(t, attachmentIn, scriptsIn[0].ID)
+	}
+}
+
+func TestUploadScriptAttachment(t *testing.T) {
+	attachmentsIn := testdata.GetAttachmentData()
+	for _, attachmentIn := range attachmentsIn {
+		UploadScriptAttachmentMocked(t, attachmentIn)
+		UploadScriptAttachmentFailStatusMocked(t, attachmentIn)
+		UploadScriptAttachmentFailErrMocked(t, attachmentIn)
+	}
+}
+
+func TestUploadedScriptAttachment(t *testing.T) {
+	attachmentsIn := testdata.GetAttachmentData()
+	for _, attachmentIn := range attachmentsIn {
+		UploadedScriptAttachmentMocked(t, attachmentIn)
+		UploadedScriptAttachmentFailErrMocked(t, attachmentIn)
+		UploadedScriptAttachmentFailStatusMocked(t, attachmentIn)
+		UploadedScriptAttachmentFailJSONMocked(t, attachmentIn)
+	}
+}
+
+func TestListScriptAttachments(t *testing.T) {
+	attachmentsIn := testdata.GetAttachmentData()
+	scriptsIn := testdata.GetScriptData()
+	ListScriptAttachmentsMocked(t, attachmentsIn, scriptsIn[0].ID)
+	ListScriptAttachmentsFailErrMocked(t, attachmentsIn, scriptsIn[0].ID)
+	ListScriptAttachmentsFailStatusMocked(t, attachmentsIn, scriptsIn[0].ID)
+	ListScriptAttachmentsFailJSONMocked(t, attachmentsIn, scriptsIn[0].ID)
+}

--- a/api/types/attachment.go
+++ b/api/types/attachment.go
@@ -1,0 +1,11 @@
+package types
+
+// Attachment stores an IMCO Attachment item
+type Attachment struct {
+	ID           string `json:"id" header:"ID"`
+	Name         string `json:"name,omitempty" header:"NAME"`
+	Uploaded     bool   `json:"uploaded,omitempty" header:"UPLOADED"`
+	UploadURL    string `json:"upload_url,omitempty" header:"UPLOAD_URL" show:"noshow,nolist"`
+	DownloadURL  string `json:"download_url,omitempty" header:"DOWNLOAD_URL" show:"nolist"`
+	ResourceType string `json:"resource_type" header:"RESOURCE_TYPE" show:"nolist"`
+}

--- a/blueprint/attachments/subcommands.go
+++ b/blueprint/attachments/subcommands.go
@@ -1,0 +1,49 @@
+package attachments
+
+import (
+	"github.com/codegangsta/cli"
+	"github.com/ingrammicro/concerto/cmd"
+)
+
+// SubCommands returns attachments commands
+func SubCommands() []cli.Command {
+	return []cli.Command{
+		{
+			Name:   "show",
+			Usage:  "Shows information about a specific attachment",
+			Action: cmd.AttachmentShow,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "id",
+					Usage: "Attachment Id",
+				},
+			},
+		},
+		{
+			Name:   "download",
+			Usage:  "Downloads an attachment",
+			Action: cmd.AttachmentDownload,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "id",
+					Usage: "Attachment Id",
+				},
+				cli.StringFlag{
+					Name:  "filepath",
+					Usage: "path and file name to download attachment file, i.e: --filename /folder-path/filename.ext",
+				},
+			},
+		},
+		{
+			Name:   "delete",
+			Usage:  "Deletes an attachment",
+			Action: cmd.AttachmentDelete,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "id",
+					Usage: "Attachment Id",
+				},
+			},
+		},
+	}
+}

--- a/blueprint/scripts/subcommands.go
+++ b/blueprint/scripts/subcommands.go
@@ -32,7 +32,7 @@ func SubCommands() []cli.Command {
 		},
 		{
 			Name:   "create",
-			Usage:  "Creates a new script to be used in the templates. ",
+			Usage:  "Creates a new script to be used in the templates",
 			Action: cmd.ScriptCreate,
 			Flags: []cli.Flag{
 				cli.StringFlag{
@@ -41,7 +41,7 @@ func SubCommands() []cli.Command {
 				},
 				cli.StringFlag{
 					Name:  "description",
-					Usage: "Description of the script's purpose ",
+					Usage: "Description of the script's purpose",
 				},
 				cli.StringFlag{
 					Name:  "code",
@@ -72,7 +72,7 @@ func SubCommands() []cli.Command {
 				},
 				cli.StringFlag{
 					Name:  "description",
-					Usage: "Description of the script's purpose ",
+					Usage: "Description of the script's purpose",
 				},
 				cli.StringFlag{
 					Name:  "code",
@@ -88,6 +88,36 @@ func SubCommands() []cli.Command {
 			Name:   "delete",
 			Usage:  "Deletes a script",
 			Action: cmd.ScriptDelete,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "id",
+					Usage: "Script Id",
+				},
+			},
+		},
+		{
+			Name:   "add-attachment",
+			Usage:  "Adds an attachment to a script",
+			Action: cmd.ScriptAttachmentAdd,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "id",
+					Usage: "Script Id",
+				},
+				cli.StringFlag{
+					Name:  "name",
+					Usage: "Name of the attachment",
+				},
+				cli.StringFlag{
+					Name:  "filepath",
+					Usage: "path to attachment file",
+				},
+			},
+		},
+		{
+			Name:   "list-attachments",
+			Usage:  "List the attachments a script has",
+			Action: cmd.ScriptAttachmentList,
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  "id",

--- a/blueprint/subcommands.go
+++ b/blueprint/subcommands.go
@@ -2,6 +2,7 @@ package blueprint
 
 import (
 	"github.com/codegangsta/cli"
+	"github.com/ingrammicro/concerto/blueprint/attachments"
 	"github.com/ingrammicro/concerto/blueprint/cookbook_versions"
 	"github.com/ingrammicro/concerto/blueprint/scripts"
 	"github.com/ingrammicro/concerto/blueprint/templates"
@@ -19,6 +20,11 @@ func SubCommands() []cli.Command {
 			Name:        "scripts",
 			Usage:       "Allow the user to manage the scripts they want to run on the servers",
 			Subcommands: append(scripts.SubCommands()),
+		},
+		{
+			Name:        "attachments",
+			Usage:       "Allow the user to manage the attachments they want to store on the servers",
+			Subcommands: append(attachments.SubCommands()),
 		},
 		{
 			Name:        "templates",

--- a/bootstrapping/bootstrapping.go
+++ b/bootstrapping/bootstrapping.go
@@ -281,13 +281,9 @@ func downloadPolicyfiles(ctx context.Context, bootstrappingSvc *blueprint.Bootst
 	for _, bsPolicyfile := range bsProcess.policyfiles {
 		tarballPath := bsPolicyfile.TarballPath(bsProcess.directoryPath)
 		log.Debug("downloading: ", tarballPath)
-		queryURL, err := bsPolicyfile.QueryURL()
-		if err != nil {
-			return err
-		}
-		_, status, err := bootstrappingSvc.DownloadPolicyfile(queryURL, tarballPath)
+		_, status, err := bootstrappingSvc.DownloadPolicyfile(bsPolicyfile.DownloadURL, tarballPath)
 		if err == nil && status != 200 {
-			err = fmt.Errorf("obtained non-ok response when downloading policyfile %s", queryURL)
+			err = fmt.Errorf("obtained non-ok response when downloading policyfile %s", bsPolicyfile.DownloadURL)
 		}
 		if err != nil {
 			return err

--- a/cmd/attachments_cmd.go
+++ b/cmd/attachments_cmd.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/Sirupsen/logrus"
+	"github.com/codegangsta/cli"
+	"github.com/ingrammicro/concerto/api/blueprint"
+	"github.com/ingrammicro/concerto/utils"
+	"github.com/ingrammicro/concerto/utils/format"
+)
+
+// WireUpAttachment prepares common resources to send request to Concerto API
+func WireUpAttachment(c *cli.Context) (scs *blueprint.AttachmentService, f format.Formatter) {
+
+	f = format.GetFormatter()
+
+	config, err := utils.GetConcertoConfig()
+	if err != nil {
+		f.PrintFatal("Couldn't wire up config", err)
+	}
+	hcs, err := utils.NewHTTPConcertoService(config)
+	if err != nil {
+		f.PrintFatal("Couldn't wire up concerto service", err)
+	}
+	scs, err = blueprint.NewAttachmentService(hcs)
+	if err != nil {
+		f.PrintFatal("Couldn't wire up attachment service", err)
+	}
+
+	return scs, f
+}
+
+// AttachmentShow subcommand function
+func AttachmentShow(c *cli.Context) error {
+	debugCmdFuncInfo(c)
+	attachmentSvc, formatter := WireUpAttachment(c)
+
+	checkRequiredFlags(c, []string{"id"}, formatter)
+	attachment, err := attachmentSvc.GetAttachment(c.String("id"))
+	if err != nil {
+		formatter.PrintFatal("Couldn't receive attachment data", err)
+	}
+
+	if err = formatter.PrintItem(*attachment); err != nil {
+		formatter.PrintFatal("Couldn't print/format result", err)
+	}
+	return nil
+}
+
+// AttachmentDownload subcommand function
+func AttachmentDownload(c *cli.Context) error {
+	debugCmdFuncInfo(c)
+	attachmentSvc, formatter := WireUpAttachment(c)
+
+	checkRequiredFlags(c, []string{"id", "filepath"}, formatter)
+	attachment, err := attachmentSvc.GetAttachment(c.String("id"))
+	if err != nil {
+		formatter.PrintFatal("Couldn't receive attachment data", err)
+	}
+
+	realFileName, status, err := attachmentSvc.DownloadAttachment(attachment.DownloadURL, c.String("filepath"))
+	if err == nil && status != 200 {
+		err = fmt.Errorf("obtained non-ok response when downloading attachment %s", attachment.DownloadURL)
+	}
+	if err != nil {
+		return err
+	}
+	logrus.Info("Available at:", realFileName)
+	return nil
+}
+
+// AttachmentDelete subcommand function
+func AttachmentDelete(c *cli.Context) error {
+	debugCmdFuncInfo(c)
+	attachmentSvc, formatter := WireUpAttachment(c)
+
+	checkRequiredFlags(c, []string{"id"}, formatter)
+	err := attachmentSvc.DeleteAttachment(c.String("id"))
+	if err != nil {
+		formatter.PrintFatal("Couldn't delete attachment", err)
+	}
+	return nil
+}

--- a/cmd/cookbook_versions_cmd.go
+++ b/cmd/cookbook_versions_cmd.go
@@ -110,12 +110,15 @@ func CookbookVersionUpload(c *cli.Context) error {
 	// uploads new cookbook_version file
 	err = svc.UploadCookbookVersion(sourceFilePath, cookbookVersion.UploadURL)
 	if err != nil {
+		cleanCookbookVersion(c, cookbookVersion.ID)
 		formatter.PrintFatal("Couldn't upload cookbook version data", err)
 	}
 
 	// processes the new cookbook_version
+	cookbookVersionID := cookbookVersion.ID
 	cookbookVersion, err = svc.ProcessCookbookVersion(utils.FlagConvertParams(c), cookbookVersion.ID)
 	if err != nil {
+		cleanCookbookVersion(c, cookbookVersionID)
 		formatter.PrintFatal("Couldn't process cookbook version", err)
 	}
 
@@ -125,6 +128,14 @@ func CookbookVersionUpload(c *cli.Context) error {
 	}
 
 	return nil
+}
+
+// cleanCookbookVersion deletes CookbookVersion. Ideally for cleaning at uploading error cases
+func cleanCookbookVersion(c *cli.Context, cookbookVersionID string) {
+	svc, formatter := WireUpCookbookVersion(c)
+	if err := svc.DeleteCookbookVersion(cookbookVersionID); err != nil {
+		formatter.PrintError("Couldn't clean failed cookbook version", err)
+	}
 }
 
 // CookbookVersionDelete subcommand function

--- a/cmd/dispatcher_cmd.go
+++ b/cmd/dispatcher_cmd.go
@@ -8,7 +8,7 @@ import (
 )
 
 // WireUpDispatcher prepares common resources to send request to API
-func WireUpDispatcher(c *cli.Context) (ds *dispatcher.DispatcherService, f format.Formatter) {
+func WireUpDispatcher(c *cli.Context) (ds *dispatcher.DispatcherService, config *utils.Config, f format.Formatter) {
 
 	f = format.GetFormatter()
 
@@ -25,5 +25,5 @@ func WireUpDispatcher(c *cli.Context) (ds *dispatcher.DispatcherService, f forma
 		f.PrintFatal("Couldn't wire up dispatcher service", err)
 	}
 
-	return ds, f
+	return ds, config, f
 }

--- a/cmd/scripts_cmd.go
+++ b/cmd/scripts_cmd.go
@@ -164,3 +164,60 @@ func ScriptDelete(c *cli.Context) error {
 	}
 	return nil
 }
+
+// ScriptAttachmentAdd subcommand function
+func ScriptAttachmentAdd(c *cli.Context) error {
+	debugCmdFuncInfo(c)
+	scriptSvc, formatter := WireUpScript(c)
+
+	checkRequiredFlags(c, []string{"id", "name", "filepath"}, formatter)
+
+	sourceFilePath := c.String("filepath")
+	if !utils.FileExists(sourceFilePath) {
+		formatter.PrintFatal("Invalid file path", fmt.Errorf("no such file or directory: %s", sourceFilePath))
+	}
+
+	attachmentIn := map[string]interface{}{
+		"name": c.String("name"),
+	}
+
+	// adds new attachment
+	attachment, err := scriptSvc.AddScriptAttachment(&attachmentIn, c.String("id"))
+	if err != nil {
+		formatter.PrintFatal("Couldn't add attachment to script", err)
+	}
+
+	// uploads new attachment file
+	err = scriptSvc.UploadScriptAttachment(sourceFilePath, attachment.UploadURL)
+	if err != nil {
+		formatter.PrintFatal("Couldn't upload attachment data", err)
+	}
+
+	// marks the attachment as "uploaded"
+	attachment, err = scriptSvc.UploadedScriptAttachment(&attachmentIn, attachment.ID)
+	if err != nil {
+		formatter.PrintFatal("Couldn't set attachment as uploaded", err)
+	}
+
+	if err = formatter.PrintItem(*attachment); err != nil {
+		formatter.PrintFatal("Couldn't print/format result", err)
+	}
+	return nil
+}
+
+// ScriptAttachmentList subcommand function
+func ScriptAttachmentList(c *cli.Context) error {
+	debugCmdFuncInfo(c)
+	scriptSvc, formatter := WireUpScript(c)
+
+	checkRequiredFlags(c, []string{"id"}, formatter)
+	attachments, err := scriptSvc.ListScriptAttachments(c.String("id"))
+	if err != nil {
+		formatter.PrintFatal("Couldn't list attachments script", err)
+	}
+
+	if err = formatter.PrintList(attachments); err != nil {
+		formatter.PrintFatal("Couldn't print/format result", err)
+	}
+	return nil
+}

--- a/cmd/scripts_cmd.go
+++ b/cmd/scripts_cmd.go
@@ -190,12 +190,15 @@ func ScriptAttachmentAdd(c *cli.Context) error {
 	// uploads new attachment file
 	err = scriptSvc.UploadScriptAttachment(sourceFilePath, attachment.UploadURL)
 	if err != nil {
+		cleanAttachment(c, attachment.ID)
 		formatter.PrintFatal("Couldn't upload attachment data", err)
 	}
 
 	// marks the attachment as "uploaded"
+	attachmentID := attachment.ID
 	attachment, err = scriptSvc.UploadedScriptAttachment(&attachmentIn, attachment.ID)
 	if err != nil {
+		cleanAttachment(c, attachmentID)
 		formatter.PrintFatal("Couldn't set attachment as uploaded", err)
 	}
 
@@ -203,6 +206,14 @@ func ScriptAttachmentAdd(c *cli.Context) error {
 		formatter.PrintFatal("Couldn't print/format result", err)
 	}
 	return nil
+}
+
+// cleanAttachment deletes Attachment. Ideally for cleaning at uploading error cases
+func cleanAttachment(c *cli.Context, attachmentID string) {
+	attachmentSvc, formatter := WireUpAttachment(c)
+	if err := attachmentSvc.DeleteAttachment(attachmentID); err != nil {
+		formatter.PrintError("Couldn't clean failed attachment", err)
+	}
 }
 
 // ScriptAttachmentList subcommand function

--- a/dispatcher/script.go
+++ b/dispatcher/script.go
@@ -28,7 +28,7 @@ func cmdShutdown(c *cli.Context) error {
 
 func execute(c *cli.Context, phase string, scriptCharacterizationUUID string) {
 	var scriptChars []*types.ScriptCharacterization
-	dispatcherSvc, formatter := cmd.WireUpDispatcher(c)
+	dispatcherSvc, config, formatter := cmd.WireUpDispatcher(c)
 
 	var err error
 	log.Debugf("Current Script Characterization %s (UUID=%s)", phase, scriptCharacterizationUUID)
@@ -74,7 +74,7 @@ func execute(c *cli.Context, phase string, scriptCharacterizationUUID string) {
 			log.Infof("Attachment Folder: %s", attachmentDir)
 			log.Infof("Attachments")
 			for _, endpoint := range sc.Script.AttachmentPaths {
-				realFileName, _, err := dispatcherSvc.DownloadAttachment(endpoint, attachmentDir)
+				realFileName, _, err := dispatcherSvc.DownloadAttachment(fmt.Sprintf("%s%s", config.APIEndpoint, endpoint), attachmentDir)
 				if err != nil {
 					formatter.PrintFatal("Couldn't download attachment", err)
 				}

--- a/testdata/attachments_data.go
+++ b/testdata/attachments_data.go
@@ -1,0 +1,25 @@
+package testdata
+
+import (
+	"github.com/ingrammicro/concerto/api/types"
+)
+
+// GetAttachmentData loads test data
+func GetAttachmentData() []*types.Attachment {
+	return []*types.Attachment{
+		{
+			ID:          "fakeID0",
+			Name:        "fakeName0",
+			UploadURL:   "fakeUploadURL0",
+			DownloadURL: "fakeDownloadURL0",
+			Uploaded:    true,
+		},
+		{
+			ID:          "fakeID1",
+			Name:        "fakeName1",
+			UploadURL:   "fakeUploadURL1",
+			DownloadURL: "fakeDownloadURL1",
+			Uploaded:    false,
+		},
+	}
+}

--- a/utils/webservice.go
+++ b/utils/webservice.go
@@ -20,7 +20,7 @@ type ConcertoService interface {
 	Put(path string, payload *map[string]interface{}) ([]byte, int, error)
 	Delete(path string) ([]byte, int, error)
 	Get(path string) ([]byte, int, error)
-	GetFile(path string, filePath string, discoveryFileName bool) (string, int, error)
+	GetFile(url string, filePath string, discoveryFileName bool) (string, int, error)
 	PutFile(sourceFilePath string, targetURL string) ([]byte, int, error)
 }
 
@@ -213,12 +213,7 @@ func (hcs *HTTPConcertoservice) Get(path string) ([]byte, int, error) {
 }
 
 // GetFile sends GET request to Concerto API and receives a file
-func (hcs *HTTPConcertoservice) GetFile(path string, filePath string, discoveryFileName bool) (string, int, error) {
-
-	url, _, err := hcs.prepareCall(path, nil)
-	if err != nil {
-		return "", 0, err
-	}
+func (hcs *HTTPConcertoservice) GetFile(url string, filePath string, discoveryFileName bool) (string, int, error) {
 
 	log.Debugf("Sending GET request to %s", url)
 	response, err := hcs.client.Get(url)

--- a/utils/webservice_mock.go
+++ b/utils/webservice_mock.go
@@ -34,8 +34,8 @@ func (m *MockConcertoService) Get(path string) ([]byte, int, error) {
 }
 
 // GetFile sends GET request to Concerto API and receives a file
-func (m *MockConcertoService) GetFile(path string, filePath string, discoveryFileName bool) (string, int, error) {
-	args := m.Called(path, filePath)
+func (m *MockConcertoService) GetFile(url string, filePath string, discoveryFileName bool) (string, int, error) {
+	args := m.Called(url, filePath)
 	return args.String(0), args.Int(1), args.Error(2)
 }
 


### PR DESCRIPTION
# Description
New _Attachments_ commands to blueprint:

**=> concerto blueprint scripts**
![imagen](https://user-images.githubusercontent.com/22797797/58972474-f033b500-87bd-11e9-8845-df0cb7a9a5d3.png)
**- concerto blueprint scripts add-attachment --id (SCRIPT_ID) --name --filepath** => POST /v2/blueprint/scripts/:script_id/attachments + PUT (PutFile) upload_url + PUT /v2/blueprint/attachments/:attachment_id/uploaded
**- concerto blueprint scripts list-attachment --id (SCRIPT_ID)** => GET /v2/blueprint/scripts/:script_id/attachments


**=> concerto blueprint attachments**
![imagen](https://user-images.githubusercontent.com/22797797/58972499-f7f35980-87bd-11e9-9171-7f67afd955bd.png)
**- concerto blueprint attachments** show -> GET /v2/blueprint/attachments/:id
**- concerto blueprint attachments** download -> GET (GetFile) download_url
**- concerto blueprint attachments** delete -> DELETE /v2/blueprint/attachments/:id


Additional:
	- Webservice::GetFile now receives complete url (covered Agent/User mode cases)

Closes #121



<!--- Describe your changes in detail -->

# Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

# Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

# How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

# Screenshots (if appropriate)

# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.