### PR TITLE
Read bootstrap config from xml and allow run-once mode 

### DIFF
--- a/bootstrapping/bootstrapping.go
+++ b/bootstrapping/bootstrapping.go
@@ -27,11 +27,12 @@ import (
 
 const (
 	//DefaultTimingInterval Default period for looping
-	DefaultTimingInterval = 600 // 600 seconds = 10 minutes
-	DefaultTimingSplay    = 360 // seconds
-	DefaultThresholdLines = 10
-	ProcessLockFile       = "cio-bootstrapping.lock"
-	RetriesNumber         = 5
+	DefaultTimingInterval       = 600 // 600 seconds = 10 minutes
+	DefaultTimingSplay          = 360 // seconds
+	DefaultThresholdLines       = 10
+	DefaultApplyAfterIterations = 4 // iterations
+	ProcessLockFile             = "cio-bootstrapping.lock"
+	RetriesNumber               = 5
 )
 
 type bootstrappingProcess struct {
@@ -139,17 +140,26 @@ func start(c *cli.Context) error {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-
 	go handleSysSignals(cancel)
 
-	timingInterval := c.Int64("interval")
-	if !(timingInterval > 0) {
-		timingInterval = DefaultTimingInterval
+	config, err := utils.GetConcertoConfig()
+	if err != nil {
+		formatter.PrintFatal("Couldn't wire up config", err)
 	}
 
-	timingSplay := c.Int64("splay")
-	if !(timingSplay > 0) {
-		timingSplay = DefaultTimingSplay
+	interval := config.BootstrapConfig.IntervalSeconds
+	if !(interval > 0) {
+		interval = DefaultTimingInterval
+	}
+
+	splay := config.BootstrapConfig.SplaySeconds
+	if !(splay > 0) {
+		splay = DefaultTimingSplay
+	}
+
+	applyAfterIterations := config.BootstrapConfig.ApplyAfterIterations
+	if !(applyAfterIterations > 0) {
+		applyAfterIterations = DefaultApplyAfterIterations
 	}
 
 	thresholdLines := c.Int("lines")
@@ -157,29 +167,12 @@ func start(c *cli.Context) error {
 		thresholdLines = DefaultThresholdLines
 	}
 	log.Debug("routine lines threshold: ", thresholdLines)
-
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	bootstrappingSvc, formatter := cmd.WireUpBootstrapping(c)
-	for {
-		applyPolicyfiles(ctx, bootstrappingSvc, formatter, thresholdLines)
 
-		// Sleep for a configured amount of time plus a random amount of time (10 minutes plus 0 to 5 minutes, for instance)
-		ticker := time.NewTicker(time.Duration(timingInterval+int64(r.Intn(int(timingSplay)))) * time.Second)
-
-		select {
-		case <-ticker.C:
-			log.Debug("ticker")
-		case <-ctx.Done():
-			log.Debug(ctx.Err())
-			log.Debug("closing bootstrapping")
-		}
-		ticker.Stop()
-		if ctx.Err() != nil {
-			break
-		}
+	if config.BootstrapConfig.RunOnce {
+		return runBootstrapOnce(ctx, bootstrappingSvc, formatter, thresholdLines, interval, splay)
 	}
-
-	return nil
+	return runBootstrapPeriodically(ctx, bootstrappingSvc, formatter, applyAfterIterations, thresholdLines, interval, splay)
 }
 
 // Stop the bootstrapping process
@@ -195,20 +188,98 @@ func stop(c *cli.Context) error {
 	return nil
 }
 
-// Subsidiary routine for commands processing
-func applyPolicyfiles(ctx context.Context, bootstrappingSvc *blueprint.BootstrappingService, formatter format.Formatter, thresholdLines int) error {
-	log.Debug("applyPolicyfiles")
+func runBootstrapPeriodically(ctx context.Context, bootstrappingSvc *blueprint.BootstrappingService, formatter format.Formatter, applyAfterIterations, thresholdLines, interval, splay int) error {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var blueprintConfig *types.BootstrappingConfiguration
+	var noPolicyfileApplicationIterations int
+	var lastPolicyfileApplicationErr, err error
+	for {
+		var updated bool
+		blueprintConfig, updated, err = getBlueprintConfig(ctx, bootstrappingSvc, blueprintConfig, formatter)
+		if err == nil {
+			if updated || lastPolicyfileApplicationErr != nil || noPolicyfileApplicationIterations >= applyAfterIterations {
+				noPolicyfileApplicationIterations = -1
+				lastPolicyfileApplicationErr = applyPolicyfiles(ctx, bootstrappingSvc, blueprintConfig, formatter, thresholdLines)
+			}
+		}
+		noPolicyfileApplicationIterations++
 
+		// Sleep for a configured amount of time plus a random amount of time (10 minutes plus 0 to 5 minutes, for instance)
+		ticker := time.NewTicker(time.Duration(interval+r.Intn(int(splay))) * time.Second)
+
+		select {
+		case <-ticker.C:
+			log.Debug("ticker")
+		case <-ctx.Done():
+			log.Debug(ctx.Err())
+			log.Debug("closing bootstrapping")
+		}
+		ticker.Stop()
+		if ctx.Err() != nil {
+			break
+		}
+	}
+	return nil
+}
+
+func runBootstrapOnce(ctx context.Context, bootstrappingSvc *blueprint.BootstrappingService, formatter format.Formatter, thresholdLines, interval, splay int) error {
+	blueprintConfig, _, err := getBlueprintConfig(ctx, bootstrappingSvc, nil, formatter)
+	if err == nil {
+		err = applyPolicyfiles(ctx, bootstrappingSvc, blueprintConfig, formatter, thresholdLines)
+	}
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; err != nil && i < 3; i++ {
+		// Sleep for a configured amount of time plus a random amount of time (10 minutes plus 0 to 5 minutes, for instance)
+		ticker := time.NewTicker(time.Duration(interval+r.Intn(int(splay))) * time.Second)
+		select {
+		case <-ticker.C:
+			log.Debug("ticker")
+		case <-ctx.Done():
+			log.Debug(ctx.Err())
+			log.Debug("interrupting bootstrapping")
+			break
+		}
+		ticker.Stop()
+		blueprintConfig, _, err = getBlueprintConfig(ctx, bootstrappingSvc, nil, formatter)
+		if err == nil {
+			err = applyPolicyfiles(ctx, bootstrappingSvc, blueprintConfig, formatter, thresholdLines)
+		}
+	}
+	return err
+}
+
+func getBlueprintConfig(ctx context.Context, bootstrappingSvc *blueprint.BootstrappingService, previousBlueprintConfig *types.BootstrappingConfiguration, formatter format.Formatter) (*types.BootstrappingConfiguration, bool, error) {
+	log.Debug("getBlueprintConfig")
 	// Inquire about desired configuration changes to be applied by querying the `GET /blueprint/configuration` endpoint. This will provide a JSON response with the desired configuration changes
-	bsConfiguration, status, err := bootstrappingSvc.GetBootstrappingConfiguration()
+	blueprintConfig, status, err := bootstrappingSvc.GetBootstrappingConfiguration()
 	if err == nil && status != 200 {
 		err = fmt.Errorf("received non-ok %d response", status)
 	}
 	if err != nil {
 		formatter.PrintError("couldn't receive bootstrapping data", err)
-		return err
+		return previousBlueprintConfig, false, err
 	}
-	err = generateWorkspaceDir()
+	updated := previousBlueprintConfig == nil
+	if !updated {
+		updated = previousBlueprintConfig.AttributeRevisionID != blueprintConfig.AttributeRevisionID
+		updated = updated || len(previousBlueprintConfig.Policyfiles) != len(blueprintConfig.Policyfiles)
+	}
+	if !updated {
+		for i, cp := range blueprintConfig.Policyfiles {
+			pp := previousBlueprintConfig.Policyfiles[i]
+			updated = cp.ID != pp.ID || cp.RevisionID != pp.RevisionID
+			if updated {
+				break
+			}
+		}
+	}
+	return blueprintConfig, updated, ctx.Err()
+}
+
+// Subsidiary routine for commands processing
+func applyPolicyfiles(ctx context.Context, bootstrappingSvc *blueprint.BootstrappingService, blueprintConfig *types.BootstrappingConfiguration, formatter format.Formatter, thresholdLines int) error {
+	log.Debug("applyPolicyfiles")
+	err := generateWorkspaceDir()
 	if err != nil {
 		formatter.PrintError("couldn't generated workspace directory", err)
 		return err
@@ -221,7 +292,7 @@ func applyPolicyfiles(ctx context.Context, bootstrappingSvc *blueprint.Bootstrap
 	}
 
 	// proto structures
-	err = initializePrototype(bsConfiguration, bsProcess)
+	err = initializePrototype(blueprintConfig, bsProcess)
 	if err != nil {
 		formatter.PrintError("couldn't initialize prototype", err)
 		return err

--- a/bootstrapping/subcommands.go
+++ b/bootstrapping/subcommands.go
@@ -15,7 +15,7 @@ func SubCommands() []cli.Command {
 				cli.IntFlag{
 					Name:  "lines, l",
 					Usage: "Maximum lines threshold per response chunk",
-					Value: DefaultThresholdLines,
+					Value: defaultThresholdLines,
 				},
 			},
 		},

--- a/bootstrapping/subcommands.go
+++ b/bootstrapping/subcommands.go
@@ -12,16 +12,6 @@ func SubCommands() []cli.Command {
 			Usage:  "Starts a bootstrapping routine to check and execute required activities",
 			Action: start,
 			Flags: []cli.Flag{
-				cli.Int64Flag{
-					Name:  "interval, i",
-					Usage: "The frequency (in seconds) at which the bootstrapping runs",
-					Value: DefaultTimingInterval,
-				},
-				cli.Int64Flag{
-					Name:  "splay, s",
-					Usage: "A random number between zero and splay that is added to interval (seconds)",
-					Value: DefaultTimingSplay,
-				},
 				cli.IntFlag{
 					Name:  "lines, l",
 					Usage: "Maximum lines threshold per response chunk",

--- a/utils/config.go
+++ b/utils/config.go
@@ -35,11 +35,12 @@ const nixServerKeyPath = "/etc/cio/client_ssl/private/key.pem"
 
 // Config stores configuration file contents
 type Config struct {
-	XMLName             xml.Name `xml:"concerto"`
-	APIEndpoint         string   `xml:"server,attr"`
-	LogFile             string   `xml:"log_file,attr"`
-	LogLevel            string   `xml:"log_level,attr"`
-	Certificate         Cert     `xml:"ssl"`
+	XMLName             xml.Name        `xml:"concerto"`
+	APIEndpoint         string          `xml:"server,attr"`
+	LogFile             string          `xml:"log_file,attr"`
+	LogLevel            string          `xml:"log_level,attr"`
+	Certificate         Cert            `xml:"ssl"`
+	BootstrapConfig     BootstrapConfig `xml:"bootstrap"`
 	ConfLocation        string
 	ConfFile            string
 	IsHost              bool
@@ -56,6 +57,14 @@ type Cert struct {
 	Cert string `xml:"cert,attr"`
 	Key  string `xml:"key,attr"`
 	Ca   string `xml:"server_ca,attr"`
+}
+
+// BootstrapConfig stores configuration specific to the bootstrap command
+type BootstrapConfig struct {
+	IntervalSeconds      int  `xml:"interval,attr"`
+	SplaySeconds         int  `xml:"splay,attr"`
+	ApplyAfterIterations int  `xml:"apply_after_iterations,attr"`
+	RunOnce              bool `xml:"run_once,attr"`
 }
 
 var cachedConfig *Config


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

- But for the lines parameter, all bootstrap configuration parameters are read from the agent xml file instead of from command line flags. Sensible default values are still applied if these are not specified in the file.
- New mode added to apply policyfiles just once and exit. If application fails it is reattempted up to 3 times.
- New apply_after_iterations parameter introduced and continuous run modified to not apply policyfiles until one of the following happens:
  - New configuration is available
  - Last application ended in error
  - During the last apply_after_iterations iterations policyfiles where not applied.
<!--- Describe your changes in detail -->

# Related Issue
Issue ingrammicro/tapp#1544
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

# Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

# How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

# Screenshots (if appropriate)

# Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.